### PR TITLE
Updated options

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -189,7 +189,7 @@ DEFAULT_LOGO_LANGUAGE=en
 
 # To ENABLE the Cloudflare tunnel, set this to 'tunnel'.
 # To DISABLE the tunnel, leave it completely blank.
-COMPOSE_PROFILES=tunnel
+COMPOSE_PROFILES=
 
 TUNNEL_TOKEN=your_token_here
 

--- a/.env.example
+++ b/.env.example
@@ -191,7 +191,7 @@ DEFAULT_LOGO_LANGUAGE=en
 # To DISABLE the tunnel, leave it completely blank.
 COMPOSE_PROFILES=
 
-TUNNEL_TOKEN=your_token_here
+TUNNEL_TOKEN=
 
 # The local port to access PostersPlus (e.g., http://localhost:8000). 
 # If you are using the tunnel and want to strictly hide the app from your 

--- a/.env.example
+++ b/.env.example
@@ -81,6 +81,8 @@ CDN_CACHE_TTL=0
 
 # JPEG output quality for composited posters (70–95). Higher = larger files.
 # Default: 85. Raise to 92 for pixel-peepers; lower to 75 to reduce storage/bandwidth.
+OUTPUT_FORMAT=webp
+WEBP_QUALITY=82
 JPEG_QUALITY=85
 
 # Seconds to keep a composited poster before re-rendering.
@@ -180,3 +182,19 @@ TEXTLESS_DETECTION_MAX_VOTES=3000
 # Falls back to English if the preferred language is unavailable.
 # This can also be passed in the URL as a parameter (see web configurator)
 DEFAULT_LOGO_LANGUAGE=en
+
+# =============================================================================
+# Deployment & Network configuration
+# =============================================================================
+
+# To ENABLE the Cloudflare tunnel, set this to 'tunnel'.
+# To DISABLE the tunnel, leave it completely blank.
+COMPOSE_PROFILES=tunnel
+
+TUNNEL_TOKEN=your_token_here
+
+# The local port to access PostersPlus (e.g., http://localhost:8000). 
+# If you are using the tunnel and want to strictly hide the app from your 
+# local network, you can bind it only to localhost by using '127.0.0.1:8000',
+# or change this port if 8000 is already in use by another app.
+HOST_PORT=8000

--- a/compose.yaml
+++ b/compose.yaml
@@ -4,18 +4,18 @@ services:
       context: .
       dockerfile: ./dockerfile
       args:
-        # Bake the PP-OCRv5 Mobile detector into the image (default). Set
-        # BAKE_PPOCR_MODEL=false in your .env for a lean image that downloads the
-        # model once at runtime instead.
         BAKE_PPOCR_MODEL: "${BAKE_PPOCR_MODEL:-true}"
-    image: PostersPlus
+    image: postersplus
+    # Maps the local port based on your .env file. Defaults to 8000.
     ports:
-      - "8000:8000"
+      - "${HOST_PORT:-8000}:8000"  
+    expose:
+      - "8000"
     restart: unless-stopped
     volumes:
-      - ./postersplus-cache:/app/cache  # cache DB, TMDB posters/logos, discovery_overrides.json
+      - ./postersplus-cache:/app/cache
     env_file:
-      - .env # see this file for an explanation of what each flag does
+      - .env
     environment: 
       - TMDB_API_KEY=${TMDB_API_KEY:-}
       - MDBLIST_API_KEY=${MDBLIST_API_KEY:-}
@@ -37,3 +37,13 @@ services:
       timeout: 5s
       retries: 3
       start_period: 15s
+
+  cloudflare:
+    image: cloudflare/cloudflared:latest
+    restart: unless-stopped
+    # This assigns the container to the 'tunnel' profile
+    profiles:
+      - tunnel
+    command: tunnel --no-autoupdate run
+    environment:
+      - TUNNEL_TOKEN=${TUNNEL_TOKEN}

--- a/config.py
+++ b/config.py
@@ -43,7 +43,9 @@ SERVER_MDBLIST_KEYS: list[str] = [k for k in [SERVER_MDBLIST_KEY, SERVER_MDBLIST
 # edge. Set to 0 to disable (e.g. when running without a CDN).
 CDN_CACHE_TTL         = int(os.environ.get("CDN_CACHE_TTL", "0"))
 # JPEG output quality for composited posters (70–95). Higher = better quality, larger files.
-JPEG_QUALITY          = max(70, min(95, int(os.environ.get("JPEG_QUALITY", "85"))))
+JPEG_QUALITY  = max(70, min(95, int(os.environ.get("JPEG_QUALITY",  "85"))))
+WEBP_QUALITY  = max(70, min(95, int(os.environ.get("WEBP_QUALITY",  "82"))))
+OUTPUT_FORMAT = os.environ.get("OUTPUT_FORMAT", "jpeg").lower().strip()
 
 # Feature Defaults 
 
@@ -292,10 +294,12 @@ SCORE_NORMALISERS = {
 # Default Sash Priority
 
 SASH_PRIORITY: list[str] = [
-    "wins",
+    "oscar_win",
+    "emmy_win",
     "gg_wins",
     "festival",
-    "pic_noms",
+    "oscar_nom",
+    "emmy_nom",
     "gg_noms",
     "studio",
     "director",
@@ -306,6 +310,8 @@ SASH_PRIORITY: list[str] = [
     "new_release",
     "metacritic",
     "true_story",
-    "structural",
+    "short",
+    "miniseries",
+    "binge",
     "release_status",
 ]

--- a/configurator.html
+++ b/configurator.html
@@ -1685,7 +1685,7 @@ try{if(localStorage.getItem('postersplus_theme')==='light')document.documentElem
       <div class="notch"></div>
       <div class="panel-header">
         <span class="panel-title">Configuration</span>
-        <button type="button" class="panel-index whatsnew-version" id="whatsnew-version" onclick="openWhatsNew()" data-acked="true" title="What's new">v1.1.0</button>
+        <button type="button" class="panel-index whatsnew-version" id="whatsnew-version" onclick="openWhatsNew()" data-acked="true" title="What's new">v1.1-dev</button>
       </div>
       <div class="panel-body">
 
@@ -1867,6 +1867,16 @@ try{if(localStorage.getItem('postersplus_theme')==='light')document.documentElem
                 <option value="medium" selected>Medium</option>
                 <option value="high">High</option>
               </select>
+              <div class="toggle-row">
+              <div>
+                <div class="toggle-label">Vignette Only With Sash</div>
+                <div class="field-hint">Only apply the top vignette if an info sash is active on the poster.</div>
+              </div>
+              <label class="toggle-switch">
+                <input type="checkbox" id="tog-top-gradient-sash-only" onchange="build(); queuePreviewReload()">
+                <div class="toggle-track"><div class="toggle-thumb"></div></div>
+              </label>
+            </div>
               <div class="field-hint">The power of the darkening applied to the top.</div>
             </div>
             <div class="field">
@@ -1899,6 +1909,16 @@ try{if(localStorage.getItem('postersplus_theme')==='light')document.documentElem
                 <option value="3">Minimalist</option>
                 <option value="4">Bar</option>
               </select>
+            </div>
+            <div class="toggle-row cfg-sep" id="rating-show-genre-toggle" style="margin-bottom:14px;">
+              <div>
+                <div class="toggle-label">Show Genre</div>
+                <div class="field-hint">Display the genre text alongside the rating/score.</div>
+              </div>
+              <label class="toggle-switch">
+                <input type="checkbox" id="tog-show-genre" checked onchange="build(); queuePreviewReload()">
+                <div class="toggle-track"><div class="toggle-thumb"></div></div>
+              </label>
             </div>
             <div id="rating-alt-colors-toggle" style="margin-bottom:14px;">
               <div class="field">
@@ -2602,22 +2622,26 @@ function onPrimaryClientChange({ rebuild = true } = {}) {
 const TMDB_IMG = 'https://image.tmdb.org/t/p/w92';
 
 const SASH_SLOTS = [
-  { id:'wins',       label:'Best Picture / Major Emmy Win',     color:'#c9a84c' },
-  { id:'gg_wins',    label:'Golden Globe Win',                  color:'#c9a84c' },
-  { id:'festival',   label:'Festival Winner',                   color:'#c9a84c' },
-  { id:'pic_noms',   label:'Best Picture / Major Emmy Nom',     color:'#9a9a9a' },
-  { id:'gg_noms',    label:'Golden Globe Nom',                  color:'#9a9a9a' },
-  { id:'studio',     label:'Notable Studio Name',               color:'#9060cc' },
-  { id:'director',   label:'Notable Director Name',             color:'#9060cc' },
-  { id:'cast',       label:'Notable Cast Name',                 color:'#4ab87a' },
-  { id:'trending',   label:'TMDB Trending Top 40',              color:'#5aaaff' },
-  { id:'cult',       label:'Cult Classic',                      color:'#5aaaff' },
-  { id:'foreign',    label:'Foreign Language',                  color:'#3ab0a8' },
-  { id:'new_release', label:'Newly Streaming (New)',                              color:'#e05555' },
-  { id:'metacritic', label:'Metacritic Must-See',               color:'#9a9a9a' },
-  { id:'true_story', label:'True Story',                        color:'#3ab0a8' },
-  { id:'structural',     label:'Short / Mini / Binge',              color:'#3ab0a8' },
-  { id:'release_status', label:'Release Status (extra API call)',    color:'#e05555' },
+  { id:'oscar_win',   label:'Best Picture',             color:'#c9a84c' },
+  { id:'emmy_win',    label:'Major Emmy Win',           color:'#c9a84c' },
+  { id:'gg_wins',     label:'Golden Globe Win',         color:'#c9a84c' },
+  { id:'festival',    label:'Festival Winner',          color:'#c9a84c' },
+  { id:'oscar_nom',   label:'Best Picture Nom',         color:'#9a9a9a' },
+  { id:'emmy_nom',    label:'Major Emmy Nom',           color:'#9a9a9a' },
+  { id:'gg_noms',     label:'Golden Globe Nom',         color:'#9a9a9a' },
+  { id:'studio',      label:'Notable Studio Name',      color:'#9060cc' },
+  { id:'director',    label:'Notable Director Name',    color:'#9060cc' },
+  { id:'cast',        label:'Notable Cast Name',        color:'#4ab87a' },
+  { id:'trending',    label:'TMDB Trending Top 40',     color:'#5aaaff' },
+  { id:'cult',        label:'Cult Classic',             color:'#5aaaff' },
+  { id:'foreign',     label:'Foreign Language',         color:'#3ab0a8' },
+  { id:'new_release', label:'Newly Streaming (New)',    color:'#e05555' },
+  { id:'metacritic',  label:'Metacritic Must-See',      color:'#9a9a9a' },
+  { id:'true_story',  label:'True Story',               color:'#3ab0a8' },
+  { id:'short',       label:'Short Film',               color:'#3ab0a8' },
+  { id:'miniseries',  label:'Miniseries',               color:'#3ab0a8' },
+  { id:'binge',       label:'Binge',                    color:'#3ab0a8' },
+  { id:'release_status', label:'Release Status (extra API call)', color:'#e05555' },
 ];
 
 // All sash slots are enabled by default.  "release_status" sits last in the
@@ -3466,9 +3490,13 @@ function buildBaseParams({ usePlaceholders = false, domainOverride = null } = {}
   params.set('top_gradient',    vEl('cfg-top-gradient')    || 'high');
   params.set('bottom_gradient', vEl('cfg-bottom-gradient') || 'high');
   params.set('fallback_to_imdb', c('tog-fallback-imdb') ? 'true' : 'false');
+  params.set('top_gradient',    vEl('cfg-top-gradient')    || 'high');
+  params.set('top_gradient_sash_only', c('tog-top-gradient-sash-only') ? 'true' : 'false');
+  params.set('bottom_gradient', vEl('cfg-bottom-gradient') || 'high');
 
   // ── Rating / Genre Label ───────────────────────────────────────────────────
   params.set('rating_display_mode', ratingMode);
+  params.set('show_genre', c('tog-show-genre') ? 'true' : 'false');
   if (ratingMode !== 0) {
     // Colour palette: exposed for the modes whose pip/score colour visibly uses it
     if (ratingMode === 1 || ratingMode === 3) {
@@ -3954,7 +3982,7 @@ function applyImport() {
 // Bump WHATS_NEW_VERSION whenever the modal content changes — existing users
 // will see the unread dot on the chip until they open and acknowledge it.
 // The chip itself stays visible so users can re-open the list whenever.
-const WHATS_NEW_VERSION = '1.1.0';
+const WHATS_NEW_VERSION = '1.0.0';
 
 function openWhatsNew() {
   document.getElementById('whatsnew-modal').classList.add('open');
@@ -4051,6 +4079,7 @@ function importUrl(urlStr, { silent = false, settingsOnly = false, preserveClien
     if (_tg === 'false' || _tg === '0' || _tg === 'no')  _tg = 'off';
     if (['off','low','medium','high'].includes(_tg)) _setEl('cfg-top-gradient', _tg);
   }
+  if (p.has('top_gradient_sash_only')) _setEl('tog-top-gradient-sash-only', p.get('top_gradient_sash_only'));
   if (p.has('bottom_gradient')) {
     const _bg = (p.get('bottom_gradient') || '').toLowerCase();
     if (['off','low','medium','high'].includes(_bg)) _setEl('cfg-bottom-gradient', _bg);
@@ -4094,6 +4123,7 @@ function importUrl(urlStr, { silent = false, settingsOnly = false, preserveClien
 
   // ── Rating display ──────────────────────────────────────────────────────
   if (p.has('rating_display_mode'))            _setEl('cfg-rating-mode',  p.get('rating_display_mode'));
+  if (p.has('show_genre'))                     _setEl('tog-show-genre',   p.get('show_genre'));
   if (p.has('accent_bar_font_size_ratio'))     _setEl('cfg-font-mode1',   p.get('accent_bar_font_size_ratio'));
   if (p.has('accent_bar_append_mode'))         _setEl('cfg-bar-append',   p.get('accent_bar_append_mode'));
   if (p.has('accent_bar_bottom_ratio'))        _setEl('cfg-bar-bottom',   p.get('accent_bar_bottom_ratio'));
@@ -4348,17 +4378,14 @@ initCustomMobileSliders();
 
 <div class="import-modal" id="whatsnew-modal" onclick="if(event.target===this)closeWhatsNew()">
   <div class="import-modal-box">
-    <div class="import-modal-title">What's new in v1.1.0</div>
+    <div class="import-modal-title">What's new in v1.0.0</div>
     <ul class="whatsnew-list">
-      <li>New Frosted Bar poster layout, with frosted, black, silver, gold, and rating-focused styles</li>
-      <li>Rebuilt textless-poster detection around a new OCR model, with background scanning and load controls for live installations</li>
-      <li>Smarter TMDB poster selection: a tiny number of votes can no longer promote a badly rated poster over substantially better artwork</li>
-      <li>Expanded artwork selection: original-art controls, language-aware poster matching, improved logo fallback, and face- and saliency-aware cropping</li>
-      <li>New notch sash style, plus release-status sashes for BluRay, Streaming, Cinema, and Production</li>
-      <li>Backdrop fallback and genre-tinted fallback canvas when no poster or textless art is available</li>
-      <li>MDBList rate-limit cooldown: automatic global pause on 429 to prevent cascade failures</li>
-      <li>New preset gallery and a reorganized, mobile-friendly tabbed configurator</li>
-      <li>New poster-output translations for French, Portuguese, and Italian</li>
+      <li>Info Sash badge style — rounded rectangle alternative to the diagonal sash, with adjustable X/Y position</li>
+      <li>Golden Globe wins and nominations now have their own dedicated sash slots</li>
+      <li>Backdrop fallback — TMDB landscape backdrop is cropped to portrait when no textless poster (or no poster at all) is available</li>
+      <li>Genre-tinted fallback canvas — atmospheric colour matched to genre when no art exists</li>
+      <li>Smoother edges — Cairo antialiasing on award badge corners and pill renders</li>
+      <li>MDBlist rate-limit cooldown — automatic global pause on 429 to prevent cascade failures</li>
     </ul>
     <div class="import-modal-btns">
       <button class="btn btn-primary" onclick="closeWhatsNew()">Got it</button>

--- a/discovery.py
+++ b/discovery.py
@@ -264,25 +264,31 @@ LANGUAGE_LABELS: dict[str, str] = {
 
 # Sash type (controls colour) for each priority slot
 _SASH_TYPES: dict[str, str] = {
-    "wins":            "win",       # gold — Oscar Best Picture + Emmy Outstanding wins
-    "gg_wins":         "win",       # gold — Golden Globe wins (separate slot)
-    "pic_noms":        "nom",       # silver — Best Picture nom + Major Emmy nom (film vs TV, never coexist)
+    "oscar_win":       "win",       # gold — Oscar Best Picture
+    "emmy_win":        "win",       # gold — Emmy Outstanding wins
+    "gg_wins":         "win",       # gold — Golden Globe wins
+    "oscar_nom":       "nom",       # silver — Best Picture nom
+    "emmy_nom":        "nom",       # silver — Major Emmy nom
+    "pic_noms":        "nom",       # silver — legacy alias
     "gg_noms":         "nom",       # silver — Golden Globe nomination
-    "emmy_noms":       "nom",       # silver — legacy alias for pic_noms
-    "noms":            "nom",       # silver — legacy catch-all for any nomination
-    "festival":        "win",       # gold — major festival win is prestige-equivalent to Oscar
-    "studio":          "prestige",  # purple — production credit
-    "director":        "prestige",  # purple — production credit
-    "cast":            "cast",      # green — talent credit
+    "emmy_noms":       "nom",       # silver — legacy alias
+    "noms":            "nom",       # silver — legacy catch-all
+    "festival":        "win",       # gold
+    "studio":          "prestige",  # purple
+    "director":        "prestige",  # purple
+    "cast":            "cast",      # green
     "trending":        "trending",  # blue
-    "cult":            "trending",  # blue — popularity signal, closest to trending without a new colour
-    "foreign":         "info",      # teal — informational / discovery
-    "new_release":     "alert",     # red — newly streaming (release date or r/movieleaks)
-    "digital_release": "alert",     # red — legacy alias for new_release
-    "metacritic":      "nom",       # silver — critical award, fits with noms not production
+    "cult":            "trending",  # blue
+    "foreign":         "info",      # teal
+    "new_release":     "alert",     # red
+    "digital_release": "alert",     # red — legacy alias
+    "metacritic":      "nom",       # silver
     "true_story":      "info",      # teal
-    "structural":      "info",      # teal
-    "release_status":  "alert",     # red — Physical / Streaming / Cinema / Production
+    "short":           "info",      # teal — previously under "structural"
+    "miniseries":      "info",      # teal — previously under "structural"
+    "binge":           "info",      # teal — previously under "structural"
+    "structural":      "info",      # teal — legacy alias
+    "release_status":  "alert",     # red
 }
 
 NEW_RELEASE_DAYS = 14
@@ -495,7 +501,25 @@ def pick_sash(
 
 def _evaluate_slot(slot: str, meta: DiscoveryMeta) -> str | None:
     """Return a label string if this slot has a match, else None."""
+    
+    # --- New Granular Award Checks ---
+    if slot == "oscar_win":
+        w = [v for v in meta.award_wins if "Best Picture" in v]
+        return w[0] if w else None
 
+    if slot == "emmy_win":
+        w = [v for v in meta.award_wins if "Emmy" in v]
+        return w[0] if w else None
+        
+    if slot == "oscar_nom":
+        match = next((n for n in meta.award_noms if "Best Picture" in n), None)
+        return match
+
+    if slot == "emmy_nom":
+        match = next((n for n in meta.award_noms if "Emmy" in n), None)
+        return match
+
+    # --- Legacy Award Checks (for backward-compat with old URLs) ---
     if slot == "wins":
         # Oscar Best Picture wins and Emmy Outstanding wins only.
         # Golden Globe wins have their own slot (gg_wins) so they can be
@@ -565,7 +589,18 @@ def _evaluate_slot(slot: str, meta: DiscoveryMeta) -> str | None:
 
     if slot == "true_story":
         return "True Story" if meta.is_true_story else None
+    
+    # --- New Granular Structural Checks ---
+    if slot == "short":
+        return "Short Film" if meta.is_short_film else None
+        
+    if slot == "miniseries":
+        return "Mini Series" if meta.is_mini_series else None
+        
+    if slot == "binge":
+        return "Binge Ready" if meta.is_binge_ready else None
 
+    # --- Legacy Structural Check (for backward-compat) ---
     if slot == "structural":
         for key in _STRUCTURAL_CHECKS:
             if key == "short_film"  and meta.is_short_film:  return _STRUCTURAL_LABELS[key]
@@ -584,10 +619,12 @@ def _evaluate_slot(slot: str, meta: DiscoveryMeta) -> str | None:
 # ---------------------------------------------------------------------------
 
 ALL_PRIORITY_SLOTS: list[str] = [
-    "wins",
+    "oscar_win",
+    "emmy_win",
     "gg_wins",
     "festival",
-    "pic_noms",
+    "oscar_nom",
+    "emmy_nom",
     "gg_noms",
     "studio",
     "director",
@@ -598,11 +635,16 @@ ALL_PRIORITY_SLOTS: list[str] = [
     "new_release",
     "metacritic",
     "true_story",
-    "structural",
-    "emmy_noms",        # legacy alias for pic_noms — still accepted in sash_priority param
-    "digital_release",  # legacy alias for new_release
-    "noms",             # legacy alias for any nomination
-    "release_status",   # opt-in: Blu-ray / Streaming / Cinema / Production — requires extra API call for movies
+    "short",
+    "miniseries",
+    "binge",
+    "wins",             # legacy alias
+    "structural",       # legacy alias
+    "pic_noms",         # legacy alias
+    "emmy_noms",        # legacy alias
+    "digital_release",  # legacy alias 
+    "noms",             # legacy alias 
+    "release_status",   
 ]
 
 

--- a/main.py
+++ b/main.py
@@ -725,6 +725,7 @@ class RequestConfig:
     textless: bool = False
     score_color_mode: int = 2
     top_gradient:    str = "high"   # off | low | medium | high — strength of the top vignette
+    top_gradient_sash_only: bool = False # only apply top vignette if a sash is present
     bottom_gradient: str = "high"   # off | low | medium | high — strength of the bottom vignette
     sash_badge: bool = False              # legacy; superseded by sash_mode (kept for back-compat parsing)
     sash_mode: str = "sash"               # "sash" (diagonal) | "notch"
@@ -738,6 +739,7 @@ class RequestConfig:
     sash_height_ratio: float = 0.12  # diagonal sash height (thickness) as fraction of poster width
     wait_for_quality: bool = False  # block response until quality is fetched (for poster-warm workflows)
     greyscale_no_quality: bool = False  # greyscale art when no quality found (needs wait_for_quality)
+    show_genre: bool = True
 
 
 def _parse_bool(val: str | None, default: bool) -> bool:
@@ -836,6 +838,7 @@ def build_request_config(params: dict) -> RequestConfig:
     elif _tg_raw in ("false", "0", "no"):
         cfg.top_gradient = "off"
     # else: leave RequestConfig default ("high")
+    cfg.top_gradient_sash_only = _b("top_gradient_sash_only", cfg.top_gradient_sash_only)
 
     # bottom_gradient — same four-level enum as top.  Brand-new param so no
     # legacy boolean form to honour; unknown values fall through to the
@@ -951,6 +954,7 @@ def build_request_config(params: dict) -> RequestConfig:
     if _oas in ("primary", "top_rated"):
         cfg.original_art_source = _oas
     cfg.sash_priority        = _parse_sash_priority(params.get("sash_priority"))
+    cfg.show_genre           = _b("show_genre", cfg.show_genre)
 
     return cfg
 
@@ -1240,6 +1244,28 @@ def build_poster(
         genre_label = _genre_tr
     else:
         genre_label = _GENRE_LABEL_OVERRIDES.get(genre, genre)
+    
+    if not cfg.show_genre:
+        genre_label = ""
+
+    # --- RESOLVE SASH EARLY ---
+    # Resolve the info-sash pick once early, so gradients can depend on its presence. This is regardless of whether the diagonal sash
+    # itself is rendered independently.
+    #
+    # When greyscale is active on an unreleased title (Cinema / Production),
+    # force the release-status slot to the front so its badge always wins — that
+    # tells the user the poster is greyscale because it's unavailable, rather
+    # than a title whose art happens to be black & white.
+    _sash_priority = cfg.sash_priority
+    if (cfg.cinema_greyscale and discovery_meta is not None
+            and discovery_meta.release_status in ("Cinema", "Production")
+            and "release_status" in _sash_priority):
+        _sash_priority = ["release_status"] + [s for s in _sash_priority if s != "release_status"]
+    sash_result = (
+        pick_sash(discovery_meta, _sash_priority)
+        if discovery_meta is not None
+        else None
+    )
 
     # --- TOP GRADIENT (vectorised) ---
     # Darkens the top of the poster so the age-rating numeral and quality
@@ -1249,6 +1275,12 @@ def build_poster(
     # treated as "high" rather than skipped so a typo in a URL doesn't
     # silently disable the vignette.
     _tg_preset = _TOP_GRADIENT_LEVELS.get(cfg.top_gradient, _TOP_GRADIENT_LEVELS["high"])
+
+    # Check if gradient should be suppressed by sash not being present
+    _apply_top = True
+    if cfg.top_gradient_sash_only and (cfg.sash_mode == "hidden" or sash_result is None):
+        _apply_top = False
+
     if _tg_preset is not None:
         top_height_ratio, top_max_alpha = _tg_preset
         top_height = int(height * top_height_ratio)
@@ -1465,24 +1497,6 @@ def build_poster(
             draw.text((tx + shadow_offset, ty + shadow_offset), line, font=font, fill=(0, 0, 0, 180))
             draw.text((tx, ty),                                  line, font=font, fill=(255, 255, 255, 255))
 
-    # Resolve the info-sash pick once, regardless of whether the diagonal sash
-    # itself is rendered independently.
-    #
-    # When greyscale is active on an unreleased title (Cinema / Production),
-    # force the release-status slot to the front so its badge always wins — that
-    # tells the user the poster is greyscale because it's unavailable, rather
-    # than a title whose art happens to be black & white.
-    _sash_priority = cfg.sash_priority
-    if (cfg.cinema_greyscale and discovery_meta is not None
-            and discovery_meta.release_status in ("Cinema", "Production")
-            and "release_status" in _sash_priority):
-        _sash_priority = ["release_status"] + [s for s in _sash_priority if s != "release_status"]
-    sash_result = (
-        pick_sash(discovery_meta, _sash_priority)
-        if discovery_meta is not None
-        else None
-    )
-
     # --- Shared frosted tint (Match Notch Colour) ---------------------------
     # When the frosted rating bar (mode 4) and a poster-coloured sash element are
     # both on (a frosted notch badge OR a poster-coloured diagonal sash) and
@@ -1534,14 +1548,17 @@ def build_poster(
                 sash_result if (_append_sash and sash_result) else (None, None)
             )
 
-            _pre_sash = [genre_label]
+            _pre_sash = [genre_label] if genre_label else []
             if _append_year and release_year:
                 _pre_sash.append(str(release_year))
             _label_main = " · ".join(_pre_sash)
 
             if _sash_text_for_label:
                 _sash_sep = " ★ " if _sash_type_for_label == "win" else " · "
-                label = _label_main + _sash_sep + translate_sash(_sash_text_for_label, cfg.logo_language)
+                if _label_main:
+                    label = _label_main + _sash_sep + translate_sash(_sash_text_for_label, cfg.logo_language)
+                else:
+                    label = translate_sash(_sash_text_for_label, cfg.logo_language)
             else:
                 label = _label_main
             rating_cy = height * cfg.accent_bar_y_offset
@@ -1578,7 +1595,7 @@ def build_poster(
                 _score_text = "10" if score >= 100 else f"{score / 10:.1f}"
             else:
                 _score_text = str(score)
-            label = f"{genre_label} ★ {_score_text}"
+            label = f"{genre_label} ★ {_score_text}" if genre_label else f"★ {_score_text}"
             rating_cy = height * cfg.numeric_score_y_offset
 
             try:
@@ -1615,7 +1632,7 @@ def build_poster(
             # Mode 1 ("Rating"): genre ★ score
             # Mode 2 ("Year + Rating"): genre [pip] year ★ score
             _has_score = score not in ("N/A", None)
-            parts = [(genre_label, None)]   # (text, separator_before)
+            parts = [(genre_label, None)] if genre_label else []   # (text, separator_before)
             if cfg.minimalist_append_mode == 0:
                 if release_year:
                     parts.append((str(release_year), "rpip"))
@@ -1766,6 +1783,69 @@ async def _cache_prune_loop() -> None:
         await asyncio.sleep(6 * 3600)   # every 6 hours
 
 
+async def trending_warmup_loop(client: httpx.AsyncClient) -> None:
+    """Fetches TMDB trending daily and pre-warms the poster cache."""
+    # Wait 60 seconds on startup to ensure the API and caches are fully ready
+    await asyncio.sleep(60)
+    
+    while True:
+        logger.info("Starting daily trending pre-warm...")
+        tmdb_key = _resolve_tmdb_key("")
+        
+        if tmdb_key:
+            try:
+                # 1. Fetch Trending from TMDB
+                resp = await client.get(
+                    "https://api.themoviedb.org/3/trending/all/day",
+                    params={"api_key": tmdb_key}
+                )
+                
+                if resp.status_code == 200:
+                    results = resp.json().get("results", [])
+                    access_key = _cfg.ACCESS_KEY or ""
+                    
+                    # 2. Iterate through trending items
+                    for item in results:
+                        tmdb_id = str(item.get("id"))
+                        media_type = item.get("media_type")
+                        
+                        if media_type not in ("movie", "tv"):
+                            continue
+                            
+                        # 3. Resolve IMDB ID internally
+                        imdb_resp = await client.get(
+                            "http://127.0.0.1:8000/resolve-imdb",
+                            params={
+                                "tmdb_id": tmdb_id, 
+                                "type": media_type, 
+                                "access_key": access_key
+                            }
+                        )
+                        
+                        if imdb_resp.status_code == 200:
+                            imdb_id = imdb_resp.json().get("imdb_id")
+                            if imdb_id:
+                                logger.info(f"Pre-warming poster for {media_type} TMDB {tmdb_id}")
+                                # 4. Trigger Poster Generation
+                                # Calling the local endpoint routes through the exact same caching pipeline.
+                                await client.get(
+                                    "http://127.0.0.1:8000/poster",
+                                    params={
+                                        "tmdb_id": tmdb_id,
+                                        "imdb_id": imdb_id,
+                                        "type": media_type,
+                                        "access_key": access_key,
+                                    }
+                                )
+                                # 2-second delay to prevent hammering external APIs (TMDB/MDBList)
+                                await asyncio.sleep(2)
+                                
+            except Exception as e:
+                logger.error(f"Trending warmup failed: {e}")
+                
+        # Sleep for 24 hours (86400 seconds)
+        await asyncio.sleep(86400)
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     global _HTTP_CLIENT, _configurator_html, _render_assets_signature
@@ -1828,9 +1908,11 @@ async def lifespan(app: FastAPI):
 
     prune_task   = asyncio.create_task(_cache_prune_loop())
     digital_task = asyncio.create_task(digital_release_poll_loop(_HTTP_CLIENT))
+    trending_task = asyncio.create_task(trending_warmup_loop(_HTTP_CLIENT))
     yield
     prune_task.cancel()
     digital_task.cancel()
+    trending_task.cancel()
     if _background_detection_task is not None:
         _background_detection_task.cancel()
     # Await the cancelled tasks so their finally: blocks finish unwinding
@@ -1839,6 +1921,8 @@ async def lifespan(app: FastAPI):
         await prune_task
     with suppress(asyncio.CancelledError):
         await digital_task
+    with suppress(asyncio.CancelledError):
+        await trending_task    
     if _background_detection_task is not None:
         with suppress(asyncio.CancelledError):
             await _background_detection_task
@@ -1975,7 +2059,8 @@ def _compute_render_assets_signature() -> str:
 def _server_render_signature() -> str:
     return "|".join((
         f"render={_RENDER_CACHE_VERSION}",
-        f"jpeg={_cfg.JPEG_QUALITY}",
+        f"format={_cfg.OUTPUT_FORMAT}",
+        f"quality={_cfg.WEBP_QUALITY if _cfg.OUTPUT_FORMAT == 'webp' else _cfg.JPEG_QUALITY}",
         f"contrast={int(_cfg.LOGO_CONTRAST_RESCUE)}",
         f"stretch={int(_cfg.LOGO_STRETCH_DISABLED)}:{_cfg.LOGO_STRETCH_FACTOR:g}",
         f"assets={_render_assets_signature}",
@@ -2068,9 +2153,11 @@ async def debug_canvas(genre: str = "Action", title: str = "Sample Title",
     cache_key = (genre, title, style, year, score)
     now = asyncio.get_running_loop().time()
     cached = _debug_canvas_cache.get(cache_key)
-    if cached is not None and now - cached[0] <= _DEBUG_CANVAS_TTL:
+    media_type = "image/webp" if _cfg.OUTPUT_FORMAT == "webp" else "image/jpeg"
+
+    if cached is not None and now - cached <= _DEBUG_CANVAS_TTL:
         return Response(
-            content=cached[1], media_type="image/jpeg",
+            content=cached, media_type=media_type,
             headers={"Cache-Control": "private, max-age=300"},
         )
     gid = _DEBUG_GENRE_IDS.get(genre)
@@ -2082,14 +2169,20 @@ async def debug_canvas(genre: str = "Action", title: str = "Sample Title",
     img = build_poster(canvas, _score, genre, cfg, fallback_title=title,
                        release_year=(year or None), no_poster=True)
     buf = io.BytesIO()
-    img.convert("RGB").save(buf, format="JPEG", quality=90)
-    jpeg = buf.getvalue()
+    if _cfg.OUTPUT_FORMAT == "webp":
+        img.convert("RGBA").save(buf, format="WEBP", quality=getattr(_cfg, 'WEBP_QUALITY', 90), method=4)
+    else:
+        img.convert("RGB").save(buf, format="JPEG", quality=getattr(_cfg, 'JPEG_QUALITY', 90))
+    
+    img_bytes = buf.getvalue()
+    
     if len(_debug_canvas_cache) >= _DEBUG_CANVAS_MAX_ENTRIES:
-        oldest = min(_debug_canvas_cache, key=lambda key: _debug_canvas_cache[key][0])
+        oldest = min(_debug_canvas_cache, key=lambda key: _debug_canvas_cache[key])
         _debug_canvas_cache.pop(oldest, None)
-    _debug_canvas_cache[cache_key] = (now, jpeg)
+    
+    _debug_canvas_cache[cache_key] = (now, img_bytes)
     return Response(
-        content=jpeg, media_type="image/jpeg",
+        content=img_bytes, media_type=media_type,
         headers={"Cache-Control": "private, max-age=300"},
     )
 
@@ -2297,6 +2390,7 @@ async def get_poster(
     muted: str | None = None,
     textless: str | None = None,
     score_color_mode: str | None = None,
+    show_genre: str | None = None,
     debug: str | None = None,
     nocache: str | None = None,
 ):
@@ -2381,15 +2475,17 @@ async def get_poster(
             ).encode()
         ).hexdigest()[:16]
         final_cache_key = f"{imdb_id}:{tmdb_id}:{type}:{_params_hash}"
-        cached_jpeg = None if _force_refresh else get_cached_final_poster(final_cache_key)
+        cached_image = None if _force_refresh else get_cached_final_poster(final_cache_key)
         if _force_refresh:
             logger.info(f"Force refresh (nocache) for {final_cache_key} — bypassing cache read")
-        if cached_jpeg is not None:
+        if cached_image is not None:
             logger.info(f"Final poster cache hit for {final_cache_key}")
             etag = f'"{final_cache_key}"'
             if request.headers.get("if-none-match") == etag:
                 return Response(status_code=304)
-            _hit_resp = Response(content=cached_jpeg, media_type="image/jpeg")
+            
+            _media_type = "image/webp" if _cfg.OUTPUT_FORMAT == "webp" else "image/jpeg"
+            _hit_resp = Response(content=cached_image, media_type=_media_type)
             _hit_resp.headers["ETag"] = etag
             # This path is only reached when composite caching is enabled, so a
             # no-store branch would be dead here — CDN TTL is the only option.
@@ -2411,7 +2507,8 @@ async def get_poster(
         if _existing_fut is not None:
             logger.info(f"Coalescing request for {final_cache_key}")
             try:
-                _coal_resp = Response(content=await _existing_fut, media_type="image/jpeg")
+                _media_type = "image/webp" if _cfg.OUTPUT_FORMAT == "webp" else "image/jpeg"
+                _coal_resp = Response(content=await _existing_fut, media_type=_media_type)
                 _coal_resp.headers["ETag"] = f'"{final_cache_key}"'
                 # Coalescing only happens when caching is on (final_cache_key set),
                 # so no-store can't apply here — CDN TTL only.
@@ -3203,7 +3300,10 @@ async def get_poster(
         def _composite_and_encode() -> bytes:
             result = build_poster(image, score, genre, rcfg, **_bp_args)
             buf = io.BytesIO()
-            result.convert("RGB").save(buf, format="JPEG", quality=_cfg.JPEG_QUALITY)
+            if _cfg.OUTPUT_FORMAT == "webp":
+                result.convert("RGBA").save(buf, format="WEBP", quality=_cfg.WEBP_QUALITY, method=4)
+            else:
+                result.convert("RGB").save(buf, format="JPEG", quality=_cfg.JPEG_QUALITY)
             return buf.getvalue()
 
         img_bytes = await asyncio.get_running_loop().run_in_executor(
@@ -3226,7 +3326,8 @@ async def get_poster(
         if _render_fut is not None:
             _render_fut.set_result(img_bytes)
 
-        response = Response(content=img_bytes, media_type="image/jpeg")
+        _media_type = "image/webp" if _cfg.OUTPUT_FORMAT == "webp" else "image/jpeg"
+        response = Response(content=img_bytes, media_type=_media_type)
         if final_cache_key is not None:
             response.headers["ETag"] = f'"{final_cache_key}"'
         if _cfg.DISABLE_COMPOSITE_CACHE:


### PR DESCRIPTION
-Option to only apply top vignette when a sash is displayed
-Option to remove genre from rating bar
-Separated sash options e.g. short/miniseries/binge are now independent options
-Included cloudflare tunnel token option in env file for easy public hosting (off by default)