### PR TITLE
More vignette controls, more sash customisation, daily trending cache prewarm, store posters as webp and other changes  

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -100,14 +100,38 @@ MDBLIST_CONCURRENCY=3
 # Set to 0 to disable (default; recommended unless you're using a CDN).
 CDN_CACHE_TTL=0
 
-# JPEG output quality for composited posters (70–95). Higher = larger files.
+# Image format for composited posters (webp or jpeg).
+# Default: webp. WebP provides better compression and smaller file sizes.
+IMAGE_FORMAT=webp
+
+# JPEG output quality for composited posters (70-95). Higher = larger files.
 # Default: 85. Raise to 92 for pixel-peepers; lower to 75 to reduce storage/bandwidth.
 JPEG_QUALITY=85
+
+# WebP output quality for composited posters (70-95). Higher = larger files.
+# Default: 85.
+WEBP_QUALITY=85
+
+# Maximum age in years for a title to fetch its release status (like Cinema, Streaming).
+# Prevents showing stale "Cinema" badges on very old titles. Default: 5.
+RELEASE_STATUS_MAX_AGE_YEARS=5
 
 # Seconds to keep a composited poster before re-rendering.
 # Default: 604800 (7 days)
 # Pruning happens automatically based on this value to avoid an ever-growing cache of dead content when users abandon configs
 COMPOSITE_CACHE_TTL=604800
+
+# The time of day to fetch the trending list (e.g. "04:00"). If empty, defaults to a 24-hour interval.
+TRENDING_FETCH_TIME=
+
+# The timezone for the schedule (e.g. "America/New_York"). Defaults to "UTC".
+TRENDING_FETCH_TIMEZONE=UTC
+
+# The number of trending items to fetch during the background cycle (default 40).
+TRENDING_FETCH_COUNT=40
+
+# The number of broad trending items to fetch during the background cycle (default 100).
+TRENDING_BROAD_FETCH_COUNT=100
 
 # Maximum composite poster cache entries. 0 = no cap (rely on TTL alone).
 # I suggest setting this on a public instance, as a failsafe.

--- a/age_badge.py
+++ b/age_badge.py
@@ -136,7 +136,7 @@ def _cairo_pill_mask(w: int, h: int, radius: int) -> Image.Image:
         surface.flush()
         stride = surface.get_stride()
         arr = np.frombuffer(bytes(surface.get_data()), dtype=np.uint8).reshape((h, stride))[:, :w].copy()
-        return Image.fromarray(arr, "L")
+        return Image.fromarray(arr)
     else:
         mask = Image.new("L", (w, h), 0)
         ImageDraw.Draw(mask).rounded_rectangle(
@@ -182,7 +182,7 @@ def _make_text_layer(
     # 3× sigma covers ~99% of a Gaussian — anything beyond that contributes
     # less than 1% intensity and is safely cropped at the layer edge.
     pad = blur * 3 if blur else 0
-    glyph_h = bb[3] - bb[1]
+    glyph_h = int(bb[3] - bb[1])
 
     if tracking and len(text) > 1:
         advances = [_PROBE.textlength(ch, font=font) for ch in text]
@@ -194,7 +194,7 @@ def _make_text_layer(
             draw.text((cx, pad - bb[1]), ch, font=font, fill=fill)
             cx += adv + tracking
     else:
-        glyph_w = bb[2] - bb[0]
+        glyph_w = int(bb[2] - bb[0])
         layer   = Image.new("RGBA", (glyph_w + 2 * pad, glyph_h + 2 * pad), (0, 0, 0, 0))
         # Draw so the glyph ink lands at (pad, pad)..(pad + glyph_w, pad + glyph_h)
         ImageDraw.Draw(layer).text(
@@ -207,7 +207,7 @@ def _make_text_layer(
 
     # Compositing the layer at this offset puts the ink where the original
     # full-canvas (xy + bb[0..1]) draw would have placed it.
-    dest = (xy[0] + bb[0] - pad, xy[1] + bb[1] - pad)
+    dest = (int(xy[0] + bb[0] - pad), int(xy[1] + bb[1] - pad))
     return layer, dest
 
 
@@ -279,8 +279,8 @@ def draw_quality_age_badge(
     # Measure text bounds once
     probe = ImageDraw.Draw(image)
     bb    = probe.textbbox((0, 0), age_text, font=font)
-    tx    = ax - bb[0]
-    ty    = ay - bb[1]
+    tx    = int(ax - bb[0])
+    ty    = int(ay - bb[1])
 
     # ── 1. Ambient glow ───────────────────────────────────────────────────
     # Large, very-soft blur centred on the glyph — creates a luminance halo

--- a/awards.py
+++ b/awards.py
@@ -3,6 +3,7 @@ import os
 import math
 import numpy as np
 from PIL import Image, ImageDraw, ImageFont, ImageFilter
+from typing import Any
 
 try:
     import cairo as _cairo
@@ -1217,7 +1218,7 @@ def parse_mdblist_awards(
 def _text_center(
     draw: ImageDraw.ImageDraw,
     text: str,
-    font: ImageFont.ImageFont,
+    font: Any,
     cx: float,
     cy: float,
 ) -> tuple[float, float]:
@@ -1348,7 +1349,7 @@ def sample_frosted_notch_rgb(
     crop_y = max(0, by_composite)
     region = image.crop((bx, crop_y, bx + badge_w, crop_y + badge_h))
     blurred = region.filter(ImageFilter.GaussianBlur(radius=max(4, int(badge_h * 0.35))))
-    thumb = blurred.resize((8, 8), Image.LANCZOS).convert("RGB")
+    thumb = blurred.resize((8, 8), Image.Resampling.LANCZOS).convert("RGB")
     arr = np.array(thumb, dtype=np.float32)
     return float(arr[:, :, 0].mean()), float(arr[:, :, 1].mean()), float(arr[:, :, 2].mean())
 
@@ -1430,7 +1431,7 @@ def draw_award_badge(
     # Measure rendered text width at SS resolution
     _tmp_d  = ImageDraw.Draw(Image.new("L", (1, 1)))
     _tbbox  = _tmp_d.textbbox((0, 0), label, font=font)
-    text_w_ss = _tbbox[2] - _tbbox[0]
+    text_w_ss = int(_tbbox[2] - _tbbox[0])
 
     # Badge width: minimum is size_ratio_w-scaled default; expands to fit text
     # with horizontal padding of ~45% of badge_h (22.5% each side).
@@ -1459,7 +1460,7 @@ def draw_award_badge(
         region = image.crop((bx, crop_y, bx + badge_w, crop_y + badge_h))
         blur_r = max(4, int(badge_h * 0.35))
         blurred = region.filter(ImageFilter.GaussianBlur(radius=blur_r))
-        blurred_ss = blurred.resize((bw, bh), Image.LANCZOS).convert("RGBA")
+        blurred_ss = blurred.resize((bw, bh), Image.Resampling.LANCZOS).convert("RGBA")
 
         # Sample dominant colour from the (lightly blurred) region — use a small
         # thumbnail so the mean is fast and noise-free.  tint_rgb (when supplied)
@@ -1467,7 +1468,7 @@ def draw_award_badge(
         if tint_rgb is not None:
             dr, dg, db = tint_rgb
         else:
-            thumb = blurred.resize((8, 8), Image.LANCZOS).convert("RGB")
+            thumb = blurred.resize((8, 8), Image.Resampling.LANCZOS).convert("RGB")
             arr_thumb = np.array(thumb, dtype=np.float32)
             dr, dg, db = arr_thumb[:, :, 0].mean(), arr_thumb[:, :, 1].mean(), arr_thumb[:, :, 2].mean()
 
@@ -1505,7 +1506,7 @@ def draw_award_badge(
         td.text((tx, ty), label, font=font, fill=(0, 0, 0, 245))
         badge_ss = Image.alpha_composite(badge_ss, txt_layer)
 
-        badge_final = badge_ss.resize((badge_w, badge_h), Image.LANCZOS)
+        badge_final = badge_ss.resize((badge_w, badge_h), Image.Resampling.LANCZOS)
         result = image.copy()
         result.alpha_composite(badge_final, (bx, by_composite))
         return result
@@ -1527,7 +1528,7 @@ def draw_award_badge(
         _txt_rgb_black = text_color if text_color is not None else (210, 210, 218)
         td.text((tx, ty), label, font=font, fill=(*_txt_rgb_black, 245))
         badge_ss = Image.alpha_composite(badge_ss, txt_layer)
-        badge_final = badge_ss.resize((badge_w, badge_h), Image.LANCZOS)
+        badge_final = badge_ss.resize((badge_w, badge_h), Image.Resampling.LANCZOS)
         result = image.copy()
         result.alpha_composite(badge_final, (bx, by_composite))
         return result
@@ -1602,7 +1603,7 @@ def draw_award_badge(
             g_s = np.clip(arr[:, :, 1].astype(np.float32) * 255.0 / safe_a, 0, 255).astype(np.uint8)
             b_s = np.clip(arr[:, :, 0].astype(np.float32) * 255.0 / safe_a, 0, 255).astype(np.uint8)
             rgba  = np.stack([r_s, g_s, b_s, arr[:, :, 3]], axis=2)
-            badge = Image.fromarray(rgba, "RGBA")
+            badge = Image.fromarray(rgba)
         except Exception:
             badge = None
 
@@ -1615,7 +1616,7 @@ def draw_award_badge(
         b_arr[:, :, 1] = darkness[:, np.newaxis]
         b_arr[:, :, 2] = np.minimum(255, (darkness * 1.3).astype(np.uint8))[:, np.newaxis]
         b_arr[:, :, 3] = body_alpha
-        body = Image.fromarray(b_arr, "RGBA")
+        body = Image.fromarray(b_arr)
 
         _nc = dict(corners=(False, False, True, True))
         body_mask = Image.new("L", (bw, bh), 0)
@@ -1638,7 +1639,7 @@ def draw_award_badge(
     # ── Text: white on dark body, with drop shadow ───────────────────────────
     txt_layer = Image.new("RGBA", (bw, bh), (0, 0, 0, 0))
     td = ImageDraw.Draw(txt_layer)
-    tx, ty = _text_center(td, label, font, bw / 2, text_cy_ss)
+    tx, ty = _text_center(td, label, font, bw // 2, text_cy_ss)
     _txt_rgb = text_color if text_color is not None else (255, 255, 255)
     td.text((tx + SS, ty + SS), label, font=font, fill=(0, 0, 0, 160))
     td.text((tx, ty),           label, font=font, fill=(*_txt_rgb, 235))
@@ -1665,7 +1666,7 @@ def sample_frosted_sash_rgb(image: Image.Image) -> tuple[float, float, float]:
     width, height = image.size
     reg = image.crop((int(width * 0.55), 0, width, int(height * 0.22)))
     blr = reg.filter(ImageFilter.GaussianBlur(radius=max(6, int(height * 0.02))))
-    th  = blr.resize((8, 8), Image.LANCZOS).convert("RGB")
+    th  = blr.resize((8, 8), Image.Resampling.LANCZOS).convert("RGB")
     ar  = np.array(th, dtype=np.float32)
     return float(ar[:, :, 0].mean()), float(ar[:, :, 1].mean()), float(ar[:, :, 2].mean())
 
@@ -1746,6 +1747,7 @@ def draw_award_sash(
     adjusted_size = sash_height * 0.85 / (len(label) ** 0.35)
     font_size     = int(min(base_size, adjusted_size)) * SS
 
+    font: Any
     try:
         font = ImageFont.truetype(os.path.join(os.path.dirname(os.path.abspath(__file__)), "fonts", "Inter-Bold.ttf"), font_size)
     except IOError:

--- a/cache.py
+++ b/cache.py
@@ -454,6 +454,32 @@ def delete_cached_final_poster(cache_key: str) -> None:
     except Exception as exc:
         logger.error(f"Final poster cache delete error: {exc}")
 
+def invalidate_final_posters(tmdb_id: str, media_type: str | None = None) -> None:
+    """Invalidate all composited posters for a specific TMDB ID.
+    Used when underlying dynamic data (like trending rank or release status)
+    changes so the next request renders a fresh poster with updated badges.
+    """
+    pattern = f"%:{tmdb_id}:{media_type}:%" if media_type else f"%:{tmdb_id}:%"
+    
+    if COMPOSITE_MEM_ENTRIES > 0:
+        with _composite_l1_lock:
+            keys_to_delete = []
+            for k in _composite_l1:
+                parts = k.split(":")
+                if len(parts) >= 3 and parts[1] == tmdb_id:
+                    if media_type is None or parts[2] == media_type:
+                        keys_to_delete.append(k)
+            for k in keys_to_delete:
+                _composite_l1.pop(k, None)
+                
+    try:
+        with _db_lock:
+            get_db().execute("DELETE FROM final_poster_cache WHERE cache_key LIKE ?", (pattern,))
+            get_db().commit()
+        logger.info(f"Invalidated final poster cache for tmdb_id={tmdb_id}")
+    except Exception as exc:
+        logger.error(f"Final poster cache invalidate error: {exc}")
+
 
 def get_cache_stats() -> dict:
     """
@@ -880,6 +906,7 @@ def set_cached_trending_snapshot(
     media_type: str,
     rankings: dict[str, int],
 ) -> None:
+    old_rankings = get_cached_trending_snapshot(media_type) or {}
     try:
         with _db_lock:
             get_db().execute(
@@ -895,6 +922,19 @@ def set_cached_trending_snapshot(
                 ),
             )
             get_db().commit()
+            
+        # Invalidate final posters for items that changed trending rank or dropped out.
+        changed_ids = set()
+        for t_id, r in rankings.items():
+            if old_rankings.get(t_id) != r:
+                changed_ids.add(t_id)
+        for t_id in old_rankings:
+            if t_id not in rankings:
+                changed_ids.add(t_id)
+                
+        for t_id in changed_ids:
+            invalidate_final_posters(t_id, media_type)
+            
     except Exception as exc:
         logger.error(f"Trending snapshot cache write error: {exc}")
 
@@ -1109,6 +1149,13 @@ def get_cached_tmdb_metadata(cache_key: str) -> dict | None:
                     "DELETE FROM tmdb_metadata_cache WHERE cache_key = ?", (cache_key,)
                 )
                 get_db().commit()
+                
+            if age_days == 9999:
+                parts = cache_key.split("_")
+                if len(parts) >= 2:
+                    m_type, t_id = parts[0], parts[1]
+                    invalidate_final_posters(t_id, m_type)
+                    
             return None
 
         # Rows created before newer metadata fields were added were migrated

--- a/cache.py
+++ b/cache.py
@@ -201,9 +201,14 @@ def init_db() -> None:
         CREATE TABLE IF NOT EXISTS final_poster_cache (
             cache_key  TEXT PRIMARY KEY,
             jpeg_bytes BLOB    NOT NULL,
-            cached_at  INTEGER NOT NULL
+            cached_at  INTEGER NOT NULL,
+            request_params TEXT
         )
     """)
+    try:
+        conn.execute("ALTER TABLE final_poster_cache ADD COLUMN request_params TEXT")
+    except Exception:
+        pass
     conn.execute(
         "CREATE INDEX IF NOT EXISTS idx_final_poster_cached_at "
         "ON final_poster_cache(cached_at)"
@@ -395,7 +400,7 @@ def get_cached_final_poster(cache_key: str) -> bytes | None:
         return None
 
 
-def set_cached_final_poster(cache_key: str, jpeg_bytes: bytes) -> None:
+def set_cached_final_poster(cache_key: str, jpeg_bytes: bytes, request_params: str = None, ttl_override: int = None) -> None:
     """Store a fully composited JPEG poster into L1 (RAM) and L2 (SQLite)."""
     # L1: always store the freshly-rendered composite so the next hit skips SQLite
     if COMPOSITE_MEM_ENTRIES > 0:
@@ -408,12 +413,17 @@ def set_cached_final_poster(cache_key: str, jpeg_bytes: bytes) -> None:
     # L2: persist to SQLite for warm restarts
     try:
         with _db_lock:
+            now = int(time.time())
+            cached_at = now
+            if ttl_override is not None and COMPOSITE_CACHE_TTL > ttl_override:
+                cached_at = now - (COMPOSITE_CACHE_TTL - ttl_override)
+                
             get_db().execute(
                 """
-                INSERT OR REPLACE INTO final_poster_cache (cache_key, jpeg_bytes, cached_at)
-                VALUES (?, ?, ?)
+                INSERT OR REPLACE INTO final_poster_cache (cache_key, jpeg_bytes, cached_at, request_params)
+                VALUES (?, ?, ?, ?)
                 """,
-                (cache_key, jpeg_bytes, int(time.time())),
+                (cache_key, jpeg_bytes, cached_at, request_params),
             )
             if COMPOSITE_MAX_ENTRIES > 0:
                 (count,) = get_db().execute(
@@ -431,6 +441,18 @@ def set_cached_final_poster(cache_key: str, jpeg_bytes: bytes) -> None:
             get_db().commit()
     except Exception as exc:
         logger.error(f"Final poster cache write error: {exc}")
+
+def delete_cached_final_poster(cache_key: str) -> None:
+    """Remove a composited poster from both L1 (RAM) and L2 (SQLite) caches."""
+    if COMPOSITE_MEM_ENTRIES > 0:
+        with _composite_l1_lock:
+            _composite_l1.pop(cache_key, None)
+    try:
+        with _db_lock:
+            get_db().execute("DELETE FROM final_poster_cache WHERE cache_key = ?", (cache_key,))
+            get_db().commit()
+    except Exception as exc:
+        logger.error(f"Final poster cache delete error: {exc}")
 
 
 def get_cache_stats() -> dict:
@@ -1063,6 +1085,23 @@ def get_cached_tmdb_metadata(cache_key: str) -> dict | None:
         ) = row
 
         age_days = (time.time() - cached_at) / 86400
+
+        if tmdb_release_date:
+            try:
+                from datetime import timezone
+                rel_dt = datetime.strptime(tmdb_release_date, "%Y-%m-%d").replace(tzinfo=timezone.utc)
+                rel_ts = rel_dt.timestamp()
+                now_ts = time.time()
+                
+                # If cached before the release date, and it is now strictly on or after the release date
+                if cached_at < rel_ts and now_ts >= rel_ts:
+                    age_days = 9999  # Force expiration
+                # If it's unreleased or released within the last 14 days, use a 1-day TTL
+                elif (now_ts < rel_ts or (now_ts - rel_ts) < 14 * 86400) and age_days > 1.0:
+                    age_days = 9999
+            except Exception:
+                pass
+
         if age_days > TMDB_METADATA_CACHE_DURATION:
             logger.info(f"TMDB metadata cache expired for {cache_key} ({age_days:.1f}d old)")
             with _db_lock:

--- a/compose.yaml
+++ b/compose.yaml
@@ -8,9 +8,9 @@ services:
         # BAKE_PPOCR_MODEL=false in your .env for a lean image that downloads the
         # model once at runtime instead.
         BAKE_PPOCR_MODEL: "${BAKE_PPOCR_MODEL:-true}"
-    image: PostersPlus
+    image: postersplus
     ports:
-      - "8000:8000"
+      - "8081:8000"
     restart: unless-stopped
     volumes:
       - ./postersplus-cache:/app/cache  # cache DB, TMDB posters/logos, discovery_overrides.json

--- a/compose.yaml
+++ b/compose.yaml
@@ -10,7 +10,7 @@ services:
         BAKE_PPOCR_MODEL: "${BAKE_PPOCR_MODEL:-true}"
     image: postersplus
     ports:
-      - "8081:8000"
+      - "8000:8000"
     restart: unless-stopped
     volumes:
       - ./postersplus-cache:/app/cache  # cache DB, TMDB posters/logos, discovery_overrides.json

--- a/config.py
+++ b/config.py
@@ -76,8 +76,18 @@ SERVER_MDBLIST_KEYS: list[str] = [k for k in [SERVER_MDBLIST_KEY, SERVER_MDBLIST
 # Cache-Control: public header so Cloudflare (or any CDN) caches them at the
 # edge. Set to 0 to disable (e.g. when running without a CDN).
 CDN_CACHE_TTL         = int(os.environ.get("CDN_CACHE_TTL", "0"))
-# JPEG output quality for composited posters (70–95). Higher = better quality, larger files.
+# Image format for composited posters (webp or jpeg). webp is recommended.
+IMAGE_FORMAT          = os.environ.get("IMAGE_FORMAT", "webp").lower()
+if IMAGE_FORMAT not in ("webp", "jpeg", "jpg"):
+    IMAGE_FORMAT = "webp"
+# JPEG output quality for composited posters (70-95). Higher = better quality, larger files.
 JPEG_QUALITY          = max(70, min(95, int(os.environ.get("JPEG_QUALITY", "85"))))
+# WebP output quality for composited posters (70-95).
+WEBP_QUALITY          = max(70, min(95, int(os.environ.get("WEBP_QUALITY", "85"))))
+
+# Maximum age in years for a title to fetch its release status (like Cinema, Streaming).
+# Prevents showing stale "Cinema" badges on very old titles.
+RELEASE_STATUS_MAX_AGE_YEARS = int(os.environ.get("RELEASE_STATUS_MAX_AGE_YEARS", "5"))
 
 # Feature Defaults 
 
@@ -141,6 +151,10 @@ DAYS_CONSIDERED_NEW          = 14
 NEW_CACHE_DURATION           = 1
 OLD_CACHE_DURATION           = 14
 TRENDING_CACHE_DURATION      = 1
+TRENDING_FETCH_TIME          = os.environ.get("TRENDING_FETCH_TIME", "").strip()
+TRENDING_FETCH_TIMEZONE      = os.environ.get("TRENDING_FETCH_TIMEZONE", "UTC").strip()
+TRENDING_FETCH_COUNT         = int(os.environ.get("TRENDING_FETCH_COUNT", "40"))
+TRENDING_BROAD_FETCH_COUNT   = int(os.environ.get("TRENDING_BROAD_FETCH_COUNT", "100"))
 # Quality (AIOStreams) TTL — separate from rating TTL because stream availability
 # for older titles is very stable.  New content keeps the 1-day window so fresh
 # encodes are picked up quickly; old content is cached for much longer.

--- a/configurator.html
+++ b/configurator.html
@@ -2785,6 +2785,7 @@ const SASH_SLOTS = [
   { id:'production', label:'Production',                  color:'#e05555' },
   { id:'ended', label:'Ended',                  color:'#e05555' },
   { id:'cancelled', label:'Cancelled',                  color:'#e05555' },
+  { id:'airing', label:'Airing',                  color:'#e05555' },
 ];
 
 // All sash slots are enabled by default.  "release_status" sits last in the

--- a/configurator.html
+++ b/configurator.html
@@ -1874,25 +1874,69 @@ try{if(localStorage.getItem('postersplus_theme')==='light')document.documentElem
               </select>
               <div class="field-hint"><a href="#" onclick="openFallbackGallery(); return false;">Displayed if no poster can be found.</a>.</div>
             </div>
-            <div class="field cfg-sep">
+            <div class="toggle-row cfg-sep" style="margin-bottom:6px;">
+              <div>
+                <div class="toggle-label">Vignette Only On Sash</div>
+                <div class="field-hint" style="margin-top:2px;">Only draw the top vignette when a sash is visible.</div>
+              </div>
+              <label class="toggle-switch">
+                <input type="checkbox" id="tog-top-vignette-sash-only" onchange="build(); queuePreviewReload()">
+                <div class="toggle-track"><div class="toggle-thumb"></div></div>
+              </label>
+            </div>
+            <div class="field">
               <label class="field-label">Top Vignette</label>
-              <select id="cfg-top-gradient" onchange="build(); queuePreviewReload()">
+              <select id="cfg-top-gradient" onchange="updateGradientFields(); build(); queuePreviewReload()">
                 <option value="off">Off</option>
                 <option value="low">Low</option>
                 <option value="medium" selected>Medium</option>
                 <option value="high">High</option>
+                <option value="custom">Custom</option>
               </select>
               <div class="field-hint">The power of the darkening applied to the top.</div>
             </div>
+            <div id="top-gradient-custom-fields" style="display:none; margin-left: 10px; margin-bottom:10px;">
+              <div class="field" style="margin-bottom:4px;">
+                <label class="field-label" style="font-size:0.85em;">Opacity</label>
+                <div class="range-row">
+                  <input type="range" id="cfg-tg-op" min="0" max="1" step="0.05" value="1.0" oninput="updateWeightRange(this,'rv-tg-op'); build(); queuePreviewReload()">
+                  <span class="range-val" id="rv-tg-op">100%</span>
+                </div>
+              </div>
+              <div class="field">
+                <label class="field-label" style="font-size:0.85em;">Height</label>
+                <div class="range-row">
+                  <input type="range" id="cfg-tg-ht" min="0" max="1" step="0.05" value="0.25" oninput="updateWeightRange(this,'rv-tg-ht'); build(); queuePreviewReload()">
+                  <span class="range-val" id="rv-tg-ht">25%</span>
+                </div>
+              </div>
+            </div>
             <div class="field">
               <label class="field-label">Bottom Vignette</label>
-              <select id="cfg-bottom-gradient" onchange="build(); queuePreviewReload()">
+              <select id="cfg-bottom-gradient" onchange="updateGradientFields(); build(); queuePreviewReload()">
                 <option value="off">Off</option>
                 <option value="low">Low</option>
                 <option value="medium">Medium</option>
                 <option value="high" selected>High</option>
+                <option value="custom">Custom</option>
               </select>
               <div class="field-hint">Lowering may hurt rating and logo legibility.</div>
+            </div>
+            <div id="bottom-gradient-custom-fields" style="display:none; margin-left: 10px; margin-bottom:10px;">
+              <div class="field" style="margin-bottom:4px;">
+                <label class="field-label" style="font-size:0.85em;">Opacity</label>
+                <div class="range-row">
+                  <input type="range" id="cfg-bg-op" min="0" max="1" step="0.05" value="1.0" oninput="updateWeightRange(this,'rv-bg-op'); build(); queuePreviewReload()">
+                  <span class="range-val" id="rv-bg-op">100%</span>
+                </div>
+              </div>
+              <div class="field">
+                <label class="field-label" style="font-size:0.85em;">Height</label>
+                <div class="range-row">
+                  <input type="range" id="cfg-bg-ht" min="0" max="1" step="0.05" value="0.25" oninput="updateWeightRange(this,'rv-bg-ht'); build(); queuePreviewReload()">
+                  <span class="range-val" id="rv-bg-ht">25%</span>
+                </div>
+              </div>
             </div>
           </div>
         </div>
@@ -1905,6 +1949,16 @@ try{if(localStorage.getItem('postersplus_theme')==='light')document.documentElem
             <span class="section-chevron">▼</span>
           </div>
           <div class="section-body">
+            <div class="toggle-row cfg-sep" style="margin-bottom:6px;">
+              <div>
+                <div class="toggle-label">Hide Genre</div>
+                <div class="field-hint" style="margin-top:2px;">Removes the genre text and associated spacers.</div>
+              </div>
+              <label class="toggle-switch">
+                <input type="checkbox" id="tog-hide-genre" onchange="build(); queuePreviewReload()">
+                <div class="toggle-track"><div class="toggle-thumb"></div></div>
+              </label>
+            </div>
             <div class="field">
               <label class="field-label">Display Mode</label>
               <select id="cfg-rating-mode" onchange="updateRatingFields(); build(); queuePreviewReload()">
@@ -2288,16 +2342,7 @@ try{if(localStorage.getItem('postersplus_theme')==='light')document.documentElem
                 <div class="toggle-track"><div class="toggle-thumb"></div></div>
               </label>
             </div>
-            <div class="toggle-row" id="sash-release-cinema-only-row">
-              <div>
-                <div class="toggle-label">Release Status: Unavailable Only</div>
-                <div class="field-hint">Only show the release status sash when a title is in cinemas or in production.</div>
-              </div>
-              <label class="toggle-switch">
-                <input type="checkbox" id="tog-release-cinema-only" checked onchange="build(); queuePreviewReload()">
-                <div class="toggle-track"><div class="toggle-thumb"></div></div>
-              </label>
-            </div>
+
             <div class="toggle-row">
               <div>
                 <div class="toggle-label">Winner Star</div>
@@ -2705,7 +2750,7 @@ const SASH_SLOTS = [
   { id:'studio',     label:'Notable Studio Name',               color:'#9060cc' },
   { id:'director',   label:'Notable Director Name',             color:'#9060cc' },
   { id:'cast',       label:'Notable Cast Name',                 color:'#4ab87a' },
-  { id:'trending',   label:'TMDB Trending Top 40',              color:'#5aaaff' },
+  { id:'trending',   label:'TMDB Trending Top {{TRENDING_FETCH_COUNT}}',              color:'#5aaaff' },
   { id:'new_season', label:'New Season',                         color:'#e05555' },
   { id:'returning',  label:'Returning',                           color:'#e05555' },
   { id:'premiere',   label:'Premiere',                            color:'#e05555' },
@@ -2716,9 +2761,16 @@ const SASH_SLOTS = [
   { id:'new_release', label:'Newly Streaming (New)',              color:'#e05555' },
   { id:'metacritic', label:'Metacritic Must-See',                 color:'#9a9a9a' },
   { id:'true_story', label:'True Story',                          color:'#3ab0a8' },
-  { id:'structural',     label:'Short / Mini / Binge',            color:'#3ab0a8' },
-  { id:'trending_broad', label:'TMDB Trending 41-100',            color:'#5aaaff' },
-  { id:'release_status', label:'Release Status',                  color:'#e05555' },
+  { id:'short_film',     label:'Short Film',            color:'#3ab0a8' },
+  { id:'mini_series',     label:'Miniseries',            color:'#3ab0a8' },
+  { id:'binge_ready',     label:'Binge Ready',            color:'#3ab0a8' },
+  { id:'trending_broad', label:'TMDB Trending {{TRENDING_FETCH_COUNT_PLUS_ONE}}-{{TRENDING_BROAD_FETCH_COUNT}}',            color:'#5aaaff' },
+  { id:'cinema', label:'Cinema',                  color:'#e05555' },
+  { id:'streaming', label:'Streaming',                  color:'#e05555' },
+  { id:'physical', label:'Physical',                  color:'#e05555' },
+  { id:'production', label:'Production',                  color:'#e05555' },
+  { id:'ended', label:'Ended',                  color:'#e05555' },
+  { id:'cancelled', label:'Cancelled',                  color:'#e05555' },
 ];
 
 // All sash slots are enabled by default.  "release_status" sits last in the
@@ -2928,6 +2980,12 @@ async function fetchServerCaps() {
     serverCaps = await resp.json();
     serverCapsLoaded = true;
     updateKeyBadges();
+    
+    if (serverCaps.trending_fetch_count) {
+      const trSash = SASH_SLOTS.find(s => s.id === 'trending');
+      if (trSash) trSash.label = `TMDB Trending Top ${serverCaps.trending_fetch_count}`;
+      buildSashList();
+    }
   } catch(e) {}
 }
 
@@ -3565,7 +3623,17 @@ function buildBaseParams({ usePlaceholders = false, domainOverride = null } = {}
   if (userTmdbKey)    params.set('tmdb_key',     usePlaceholders ? '{tmdb_key}'    : userTmdbKey);
   if (userMdblistKey) params.set('mdblist_key',  usePlaceholders ? '{mdblist_key}' : userMdblistKey);
   params.set('top_gradient',    vEl('cfg-top-gradient')    || 'high');
+  if (vEl('cfg-top-gradient') === 'custom') {
+    params.set('top_gradient_opacity', document.getElementById('cfg-tg-op').value);
+    params.set('top_gradient_height', document.getElementById('cfg-tg-ht').value);
+  }
   params.set('bottom_gradient', vEl('cfg-bottom-gradient') || 'high');
+  if (vEl('cfg-bottom-gradient') === 'custom') {
+    params.set('bottom_gradient_opacity', document.getElementById('cfg-bg-op').value);
+    params.set('bottom_gradient_height', document.getElementById('cfg-bg-ht').value);
+  }
+  if (c('tog-top-vignette-sash-only')) params.set('top_vignette_sash_only', 'true');
+  if (c('tog-hide-genre')) params.set('hide_genre', 'true');
   params.set('fallback_to_imdb', c('tog-fallback-imdb') ? 'true' : 'false');
 
   // ── Rating / Genre Label ───────────────────────────────────────────────────
@@ -3632,7 +3700,7 @@ function buildBaseParams({ usePlaceholders = false, domainOverride = null } = {}
   params.set('sash_mode', sashMode);
   params.set('cinema_greyscale', c('tog-cinema-greyscale') ? 'true' : 'false');
   params.set('cinema_greyscale_skip_if_available', c('tog-cinema-greyscale-skip') ? 'true' : 'false');
-  params.set('release_status_cinema_only', c('tog-release-cinema-only') ? 'true' : 'false');
+
   if (showSash) {
     if (c('tog-sash-winner-star')) params.set('sash_winner_star', 'true');
     const _stc = document.getElementById('cfg-sash-text-color').value.trim();
@@ -3825,7 +3893,7 @@ function updateSashBadgeFields() {
   const isBand  = mode === 'sash';   // category/poster + muted apply to diagonal sash
   const shown   = mode !== 'hidden';
   // Release-status-only filter does nothing when no sash is drawn.
-  document.getElementById('sash-release-cinema-only-row').style.display = shown ? '' : 'none';
+
   document.getElementById('sash-style-field').style.display      = isNotch ? '' : 'none';
   document.getElementById('sash-text-color-field').style.display = shown ? '' : 'none';
   document.getElementById('sash-muted-row').style.display        = isBand ? '' : 'none';
@@ -3880,6 +3948,11 @@ function _updateBarRatingRows() {
   // Match Notch Colour only applies to frosted-bodied styles.
   document.getElementById('bar-match-notch-row').style.display =
     (s === 'frosted' || s === 'rating_frosted') ? '' : 'none';
+}
+
+function updateGradientFields() {
+  document.getElementById('top-gradient-custom-fields').style.display = document.getElementById('cfg-top-gradient').value === 'custom' ? 'block' : 'none';
+  document.getElementById('bottom-gradient-custom-fields').style.display = document.getElementById('cfg-bottom-gradient').value === 'custom' ? 'block' : 'none';
 }
 
 function updateRatingFields() {
@@ -4180,12 +4253,23 @@ function importUrl(urlStr, { silent = false, settingsOnly = false, preserveClien
     let _tg = (p.get('top_gradient') || '').toLowerCase();
     if (_tg === 'true'  || _tg === '1' || _tg === 'yes') _tg = 'high';
     if (_tg === 'false' || _tg === '0' || _tg === 'no')  _tg = 'off';
-    if (['off','low','medium','high'].includes(_tg)) _setEl('cfg-top-gradient', _tg);
+    if (['off','low','medium','high','custom'].includes(_tg)) _setEl('cfg-top-gradient', _tg);
+    if (_tg === 'custom') {
+      if (p.has('top_gradient_opacity')) { const el = document.getElementById('cfg-tg-op'); el.value = p.get('top_gradient_opacity'); updateWeightRange(el, 'rv-tg-op'); }
+      if (p.has('top_gradient_height')) { const el = document.getElementById('cfg-tg-ht'); el.value = p.get('top_gradient_height'); updateWeightRange(el, 'rv-tg-ht'); }
+    }
   }
   if (p.has('bottom_gradient')) {
     const _bg = (p.get('bottom_gradient') || '').toLowerCase();
-    if (['off','low','medium','high'].includes(_bg)) _setEl('cfg-bottom-gradient', _bg);
+    if (['off','low','medium','high','custom'].includes(_bg)) _setEl('cfg-bottom-gradient', _bg);
+    if (_bg === 'custom') {
+      if (p.has('bottom_gradient_opacity')) { const el = document.getElementById('cfg-bg-op'); el.value = p.get('bottom_gradient_opacity'); updateWeightRange(el, 'rv-bg-op'); }
+      if (p.has('bottom_gradient_height')) { const el = document.getElementById('cfg-bg-ht'); el.value = p.get('bottom_gradient_height'); updateWeightRange(el, 'rv-bg-ht'); }
+    }
   }
+  if (p.has('top_vignette_sash_only')) _setEl('tog-top-vignette-sash-only', p.get('top_vignette_sash_only'));
+  if (p.has('hide_genre')) _setEl('tog-hide-genre', p.get('hide_genre'));
+  updateGradientFields();
   if (p.has('fallback_to_imdb')) _setEl('tog-fallback-imdb', p.get('fallback_to_imdb'));
 
   // ── Sash ────────────────────────────────────────────────────────────────
@@ -4199,7 +4283,7 @@ function importUrl(urlStr, { silent = false, settingsOnly = false, preserveClien
   if (p.has('sash_winner_star')) _setEl('tog-sash-winner-star',  p.get('sash_winner_star'));
   if (p.has('cinema_greyscale')) _setEl('tog-cinema-greyscale', p.get('cinema_greyscale'));
   if (p.has('cinema_greyscale_skip_if_available')) _setEl('tog-cinema-greyscale-skip', p.get('cinema_greyscale_skip_if_available'));
-  if (p.has('release_status_cinema_only')) _setEl('tog-release-cinema-only', p.get('release_status_cinema_only'));
+
   if (p.has('muted'))           _setEl('tog-muted',         p.get('muted'));
   // sash_mode supersedes the legacy show_award_sash + sash_badge bools.
   if (p.has('sash_mode'))                _setEl('cfg-sash-mode', p.get('sash_mode'));
@@ -4374,8 +4458,11 @@ buildWeightSection('movie-weights', MOVIE_SOURCES, DEFAULT_MOVIE_W);
 buildWeightSection('tv-weights',    TV_SOURCES,    DEFAULT_TV_W);
 
 document.querySelectorAll('input[type="range"]').forEach(el => {
-  const m = el.getAttribute('oninput')?.match(/updateRange\(this,'([^']+)'\)/);
-  if (m && document.getElementById(m[1])) updateRange(el, m[1]);
+  const m = el.getAttribute('oninput')?.match(/update(?:Weight)?Range\(this,'([^']+)'\)/);
+  if (m && document.getElementById(m[1])) {
+    if (m[0].includes('Weight')) updateWeightRange(el, m[1]);
+    else updateRange(el, m[1]);
+  }
   else {
     const pct = ((parseFloat(el.value) - parseFloat(el.min)) / (parseFloat(el.max) - parseFloat(el.min)) * 100).toFixed(1) + '%';
     el.style.setProperty('--pct', pct);

--- a/configurator.html
+++ b/configurator.html
@@ -1802,6 +1802,14 @@ try{if(localStorage.getItem('postersplus_theme')==='light')document.documentElem
               <input type="text" id="cfg-mdblist-key" placeholder="If blank uses server key." oninput="build(); queuePreviewReload(); saveApiKeys()">
               <div class="field-hint" id="mdblist-key-hint" style="display:none"></div>
             </div>
+            
+            <div class="field" id="trending-schedule-field" style="display:none; margin-top: 12px; padding: 10px; background: rgba(255,255,255,0.03); border-radius: 6px; border: 1px solid rgba(255,255,255,0.08);">
+              <label class="field-label" style="display:flex; align-items:center; gap:6px;">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"></circle><polyline points="12 6 12 12 16 14"></polyline></svg>
+                Trending Refresh Schedule
+              </label>
+              <div class="field-hint" id="trending-schedule-hint" style="margin-top:4px;"></div>
+            </div>
             <div class="field">
               <label class="field-label">Primary Client</label>
               <select id="cfg-primary-client" onchange="onPrimaryClientChange()">
@@ -2985,6 +2993,20 @@ async function fetchServerCaps() {
       const trSash = SASH_SLOTS.find(s => s.id === 'trending');
       if (trSash) trSash.label = `TMDB Trending Top ${serverCaps.trending_fetch_count}`;
       buildSashList();
+    }
+    
+    const trField = document.getElementById('trending-schedule-field');
+    const trHint = document.getElementById('trending-schedule-hint');
+    if (trField && trHint) {
+      if (serverCaps.trending_fetch_time) {
+        trField.style.display = '';
+        const t = serverCaps.trending_fetch_time;
+        const tz = serverCaps.trending_fetch_timezone || 'UTC';
+        const hr = serverCaps.trending_next_refresh_hours;
+        trHint.innerHTML = `Refreshes occur at <strong>${t}</strong> (${tz}).<br>Next refresh is in <strong>${hr} hours</strong>.`;
+      } else {
+        trField.style.display = 'none';
+      }
     }
   } catch(e) {}
 }

--- a/configurator.html
+++ b/configurator.html
@@ -1546,7 +1546,11 @@
       border: 1px solid var(--border);
       box-shadow: 0 16px 48px rgba(0,0,0,0.6);
       overflow: hidden;
-      transition: width 0.25s ease, height 0.25s ease;
+      transition: width 0.25s ease, height 0.25s ease, top 0.25s ease, bottom 0.25s ease;
+    }
+    .preview-panel.preview-at-top {
+      bottom: auto;
+      top: 12px;
     }
     .preview-panel .panel-header,
     .preview-panel .preview-meta,
@@ -1791,6 +1795,7 @@ try{if(localStorage.getItem('postersplus_theme')==='light')document.documentElem
             <div class="field">
               <div class="field-label-row">
                 <label class="field-label"><a href="https://www.themoviedb.org/settings/api" target="_blank" style="color:inherit;text-decoration:none;border-bottom:1px solid var(--text-muted);">TMDB API Key</a></label>
+                <span id="tmdb-key-badge" style="display:none;"></span>
               </div>
               <input type="text" id="cfg-tmdb-key" placeholder="If blank uses server key." oninput="build(); queuePreviewReload(); saveApiKeys()">
               <div class="field-hint" id="tmdb-key-hint" style="display:none"></div>
@@ -1798,6 +1803,7 @@ try{if(localStorage.getItem('postersplus_theme')==='light')document.documentElem
             <div class="field">
               <div class="field-label-row">
                 <label class="field-label"><a href="https://mdblist.com/preferences/" target="_blank" style="color:inherit;text-decoration:none;border-bottom:1px solid var(--text-muted);">MDBList API Key</a></label>
+                <span id="mdblist-key-badge" style="display:none;"></span>
               </div>
               <input type="text" id="cfg-mdblist-key" placeholder="If blank uses server key." oninput="build(); queuePreviewReload(); saveApiKeys()">
               <div class="field-hint" id="mdblist-key-hint" style="display:none"></div>
@@ -2867,6 +2873,17 @@ previewPanel.addEventListener('click', () => {
 document.getElementById('preview-frame').addEventListener('click', () => {
   if (previewPanel.classList.contains('expanded')) collapsePreview();
 });
+
+window.addEventListener('scroll', () => {
+  if (!_isMobileViewport()) return;
+  // When scrolled to the bottom (with a 50px buffer), move preview to top right
+  const scrolledToBottom = window.innerHeight + window.scrollY >= document.body.offsetHeight - 50;
+  if (scrolledToBottom && !previewPanel.classList.contains('expanded')) {
+    previewPanel.classList.add('preview-at-top');
+  } else {
+    previewPanel.classList.remove('preview-at-top');
+  }
+}, { passive: true });
 
 function showTab(tab) {
   document.querySelectorAll('.section').forEach(s => {

--- a/discovery.py
+++ b/discovery.py
@@ -553,16 +553,33 @@ def extract_discovery_meta(
         last_ep = tmdb_data.get("last_episode") or None
         seasons = tmdb_data.get("seasons") or []
 
-        episode_for_season = next_ep if _is_recent_or_upcoming(_episode_date(next_ep)) else last_ep
-        if not _is_recent_or_upcoming(_episode_date(episode_for_season)):
-            episode_for_season = None
+        last_is_active = _is_recent_or_upcoming(_episode_date(last_ep))
+        next_is_active = _is_recent_or_upcoming(_episode_date(next_ep))
 
-        ep_season = _episode_season(episode_for_season)
-        ep_number = _episode_number(episode_for_season)
-        if ep_season and ep_season > 1:
-            if ep_number == 1:
+        last_season = _episode_season(last_ep)
+        next_season = _episode_season(next_ep)
+
+        active_season = None
+        if next_is_active and next_season and next_season > 1:
+            active_season = next_season
+        elif last_is_active and last_season and last_season > 1:
+            active_season = last_season
+
+        if active_season:
+            is_new_season = False
+            for s in seasons:
+                try:
+                    s_num = int(s.get("season_number", 0))
+                except (TypeError, ValueError):
+                    continue
+                if s_num == active_season:
+                    if _is_recent_or_upcoming(s.get("air_date")):
+                        is_new_season = True
+                    break
+            
+            if is_new_season:
                 meta.is_new_season = True
-            elif ep_number and episode_for_season:
+            else:
                 meta.is_returning = True
 
         last_season = _episode_season(last_ep)

--- a/discovery.py
+++ b/discovery.py
@@ -712,7 +712,7 @@ def _evaluate_slot(slot: str, meta: DiscoveryMeta) -> str | None:
     if slot == "release_status":
         return meta.release_status  # already a display string or None
 
-    if slot in ("cinema", "streaming", "physical", "production", "ended", "cancelled"):
+    if slot in ("cinema", "streaming", "physical", "production", "ended", "cancelled", "airing"):
         if meta.release_status and meta.release_status.lower() == slot:
             return meta.release_status
         return None
@@ -759,6 +759,7 @@ ALL_PRIORITY_SLOTS: list[str] = [
     "production",
     "ended",
     "cancelled",
+    "airing",
 ]
 
 

--- a/discovery.py
+++ b/discovery.py
@@ -71,6 +71,7 @@ from dataclasses import dataclass, field
 from datetime import date, datetime
 
 from config import SASH_PRIORITY as DEFAULT_SASH_PRIORITY  # single source of truth
+import config as _cfg
 
 logger = logging.getLogger(__name__)
 
@@ -293,6 +294,15 @@ _SASH_TYPES: dict[str, str] = {
     "true_story":      "info",      # teal
     "structural":      "info",      # teal
     "release_status":  "alert",     # red — Physical / Streaming / Cinema / Production
+    "short_film":      "info",
+    "mini_series":     "info",
+    "binge_ready":     "info",
+    "cinema":          "alert",
+    "streaming":       "alert",
+    "physical":        "alert",
+    "production":      "alert",
+    "ended":           "alert",
+    "cancelled":       "alert",
 }
 
 NEW_RELEASE_DAYS = 14
@@ -649,10 +659,10 @@ def _evaluate_slot(slot: str, meta: DiscoveryMeta) -> str | None:
         return meta.matched_cast[0] if meta.matched_cast else None
 
     if slot == "trending":
-        return f"#{meta.trending_rank} Today" if meta.trending_rank and meta.trending_rank <= 40 else None
+        return f"#{meta.trending_rank} Today" if meta.trending_rank and meta.trending_rank <= _cfg.TRENDING_FETCH_COUNT else None
 
     if slot == "trending_broad":
-        return f"#{meta.trending_rank} Today" if meta.trending_rank and 40 < meta.trending_rank <= 100 else None
+        return f"#{meta.trending_rank} Today" if meta.trending_rank and _cfg.TRENDING_FETCH_COUNT < meta.trending_rank <= _cfg.TRENDING_BROAD_FETCH_COUNT else None
 
     if slot == "new_season":
         return "New Season" if meta.is_new_season else None
@@ -693,8 +703,19 @@ def _evaluate_slot(slot: str, meta: DiscoveryMeta) -> str | None:
             if key == "binge_ready" and meta.is_binge_ready:  return _STRUCTURAL_LABELS[key]
         return None
 
+    if slot in ("short_film", "mini_series", "binge_ready"):
+        if slot == "short_film" and meta.is_short_film: return _STRUCTURAL_LABELS[slot]
+        if slot == "mini_series" and meta.is_mini_series: return _STRUCTURAL_LABELS[slot]
+        if slot == "binge_ready" and meta.is_binge_ready: return _STRUCTURAL_LABELS[slot]
+        return None
+
     if slot == "release_status":
         return meta.release_status  # already a display string or None
+
+    if slot in ("cinema", "streaming", "physical", "production", "ended", "cancelled"):
+        if meta.release_status and meta.release_status.lower() == slot:
+            return meta.release_status
+        return None
 
     return None
 
@@ -729,6 +750,15 @@ ALL_PRIORITY_SLOTS: list[str] = [
     "digital_release",  # legacy alias for new_release
     "noms",             # legacy alias for any nomination
     "release_status",   # opt-in: Blu-ray / Streaming / Cinema / Production — requires extra API call for movies
+    "short_film",
+    "mini_series",
+    "binge_ready",
+    "cinema",
+    "streaming",
+    "physical",
+    "production",
+    "ended",
+    "cancelled",
 ]
 
 

--- a/genre_backgrounds.py
+++ b/genre_backgrounds.py
@@ -58,7 +58,7 @@ def _value_noise(seed: int, scale: int) -> np.ndarray:
     rng = np.random.default_rng(seed)
     sw, sh = max(2, W // scale), max(2, H // scale)
     small = (rng.random((sh, sw)) * 255).astype(np.uint8)
-    img = Image.fromarray(small, "L").resize((W, H), Image.BICUBIC)
+    img = Image.fromarray(small, "L").resize((W, H), Image.Resampling.BICUBIC)
     return np.asarray(img, dtype=np.float32) / 255.0
 
 

--- a/main.py
+++ b/main.py
@@ -2604,6 +2604,24 @@ async def remove_server_header(request: Request, call_next):
 async def server_caps(access_key: str = ""):
     if _cfg.ACCESS_KEY and not hmac.compare_digest(access_key, _cfg.ACCESS_KEY):
         raise HTTPException(status_code=403, detail="Unauthorized")
+    next_refresh_hours = None
+    if _cfg.TRENDING_FETCH_TIME:
+        import zoneinfo
+        from datetime import datetime, timedelta
+        try:
+            tz = zoneinfo.ZoneInfo(_cfg.TRENDING_FETCH_TIMEZONE)
+        except Exception:
+            tz = zoneinfo.ZoneInfo("UTC")
+        try:
+            h, m = map(int, _cfg.TRENDING_FETCH_TIME.split(':'))
+            now_dt = datetime.now(tz)
+            target_dt = now_dt.replace(hour=h, minute=m, second=0, microsecond=0)
+            if target_dt <= now_dt:
+                target_dt += timedelta(days=1)
+            next_refresh_hours = round((target_dt - now_dt).total_seconds() / 3600, 1)
+        except Exception:
+            pass
+
     return {
         "tmdb_key_set":          bool(_cfg.SERVER_TMDB_KEY),
         "mdblist_key_set":       bool(_cfg.SERVER_MDBLIST_KEYS),
@@ -2614,6 +2632,9 @@ async def server_caps(access_key: str = ""):
             or (_cfg.QUALITY_SOURCE == "scraper" and bool(_cfg.SCRAPER_URL))
         ),
         "trending_fetch_count":  _cfg.TRENDING_FETCH_COUNT,
+        "trending_fetch_time":   _cfg.TRENDING_FETCH_TIME,
+        "trending_fetch_timezone": _cfg.TRENDING_FETCH_TIMEZONE,
+        "trending_next_refresh_hours": next_refresh_hours,
     }
 
 

--- a/main.py
+++ b/main.py
@@ -845,13 +845,34 @@ def _parse_sash_priority(raw: str | None) -> list[str]:
     # Tokens prefixed with "-" are explicit exclusions
     excluded  = {t[1:] for t in tokens if t.startswith("-") and t[1:] in ALL_PRIORITY_SLOTS}
     active    = [t      for t in tokens if not t.startswith("-") and t in ALL_PRIORITY_SLOTS]
+    
+    if "structural" in active:
+        idx = active.index("structural")
+        expanded = [s for s in ["short_film", "mini_series", "binge_ready"] if s not in excluded and s not in active]
+        active = active[:idx] + expanded + active[idx+1:]
+        
+    if "release_status" in active:
+        idx = active.index("release_status")
+        expanded = [s for s in ["cinema", "streaming", "physical", "production", "ended", "cancelled", "airing"] if s not in excluded and s not in active]
+        active = active[:idx] + expanded + active[idx+1:]
+        
     if not active and not excluded:
         return list(_cfg.SASH_PRIORITY)
     # Append any default slots that weren't explicitly listed or excluded
     active_set = set(active)
     for slot in _cfg.SASH_PRIORITY:
         if slot not in active_set and slot not in excluded:
-            active.append(slot)
+            if slot == "structural":
+                expanded = [s for s in ["short_film", "mini_series", "binge_ready"] if s not in excluded and s not in active_set]
+                active.extend(expanded)
+                active_set.update(expanded)
+            elif slot == "release_status":
+                expanded = [s for s in ["cinema", "streaming", "physical", "production", "ended", "cancelled", "airing"] if s not in excluded and s not in active_set]
+                active.extend(expanded)
+                active_set.update(expanded)
+            else:
+                active.append(slot)
+                active_set.add(slot)
     return active
 
 
@@ -3986,7 +4007,7 @@ async def get_poster(
         # ------------------------------------------------------------------
         _release_status: str | None = None
         _recent_digital_release_date: str | None = None
-        _rs_slots = {"release_status", "cinema", "streaming", "physical", "production", "ended", "cancelled"}
+        _rs_slots = {"release_status", "cinema", "streaming", "physical", "production", "ended", "cancelled", "airing"}
         if any(s in rcfg.sash_priority for s in _rs_slots):
             _fetch_rs = True
             

--- a/main.py
+++ b/main.py
@@ -9,6 +9,8 @@ import re
 import time
 import httpx
 import numpy as np
+from datetime import datetime, timedelta, timezone
+import zoneinfo
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import asynccontextmanager, suppress
 from dataclasses import dataclass, field
@@ -539,9 +541,10 @@ from cache import (
     get_cached_quality,
     get_cached_rating,
     get_cached_final_poster,
+    set_cached_final_poster,
+    delete_cached_final_poster,
     get_cached_tmdb_poster,
     get_cached_tmdb_metadata,
-    set_cached_final_poster,
     get_cached_text_detection,
     set_cached_text_detection,
     init_db,
@@ -552,6 +555,7 @@ from cache import (
     get_cache_stats,
     get_app_state,
     set_app_state,
+    get_db,
 )
 from digital_release import digital_release_poll_loop
 import config as _cfg
@@ -690,7 +694,7 @@ class RequestConfig:
     sash_poster_color:   bool = False   # diagonal sash colour derived from poster art
     cinema_greyscale:    bool = True    # greyscale art when release_status == "Cinema"
     cinema_greyscale_skip_if_available: bool = False  # keep colour if Web/Remux source found
-    release_status_cinema_only: bool = True   # only show release status when "Cinema"
+    release_status_cinema_only: bool = False  # only show release status when "Cinema"
     badge_display_mode:  int  = field(default_factory=lambda: _cfg.BADGE_DISPLAY_MODE)
     rating_display_mode: int  = field(default_factory=lambda: _cfg.SHOW_RATING_DISPLAY_MODE)
 
@@ -773,9 +777,15 @@ class RequestConfig:
     sash_priority: list[str] = field(default_factory=lambda: list(_cfg.SASH_PRIORITY))
     muted: bool = False
     textless: bool = False
+    top_gradient:    str = "high"   # off | low | medium | high | custom - strength of the top vignette
+    bottom_gradient: str = "high"   # off | low | medium | high | custom - strength of the bottom vignette
+    top_vignette_sash_only: bool = False
+    top_gradient_opacity: float | None = None
+    top_gradient_height: float | None = None
+    bottom_gradient_opacity: float | None = None
+    bottom_gradient_height: float | None = None
+    hide_genre: bool = False
     score_color_mode: int = 2
-    top_gradient:    str = "high"   # off | low | medium | high — strength of the top vignette
-    bottom_gradient: str = "high"   # off | low | medium | high — strength of the bottom vignette
     sash_badge: bool = False              # legacy; superseded by sash_mode (kept for back-compat parsing)
     sash_mode: str = "sash"               # "sash" (diagonal) | "notch"
     sash_badge_style:  str   = "frosted" # "silver" | "gold" | "frosted"
@@ -899,6 +909,8 @@ def build_request_config(params: dict) -> RequestConfig:
         cfg.top_gradient = "high"
     elif _tg_raw in ("false", "0", "no"):
         cfg.top_gradient = "off"
+    elif _tg_raw == "custom":
+        cfg.top_gradient = "custom"
     # else: leave RequestConfig default ("high")
 
     # bottom_gradient — same four-level enum as top.  Brand-new param so no
@@ -907,6 +919,28 @@ def build_request_config(params: dict) -> RequestConfig:
     _bg_raw = (params.get("bottom_gradient") or "").strip().lower()
     if _bg_raw in _BOTTOM_GRADIENT_LEVELS:
         cfg.bottom_gradient = _bg_raw
+    elif _bg_raw == "custom":
+        cfg.bottom_gradient = "custom"
+
+    cfg.top_vignette_sash_only = _b("top_vignette_sash_only", cfg.top_vignette_sash_only)
+    val_tgo = params.get("top_gradient_opacity")
+    if val_tgo is not None:
+        try: cfg.top_gradient_opacity = float(val_tgo)
+        except ValueError: pass
+    val_tgh = params.get("top_gradient_height")
+    if val_tgh is not None:
+        try: cfg.top_gradient_height = float(val_tgh)
+        except ValueError: pass
+    val_bgo = params.get("bottom_gradient_opacity")
+    if val_bgo is not None:
+        try: cfg.bottom_gradient_opacity = float(val_bgo)
+        except ValueError: pass
+    val_bgh = params.get("bottom_gradient_height")
+    if val_bgh is not None:
+        try: cfg.bottom_gradient_height = float(val_bgh)
+        except ValueError: pass
+    cfg.hide_genre = _b("hide_genre", cfg.hide_genre)
+
     cfg.sash_badge              = _b("sash_badge",              cfg.sash_badge)
     # sash_mode supersedes the legacy sash_badge bool; fall back to it for old
     # URLs/presets (sash_badge=true → notch, false → diagonal sash).
@@ -1309,6 +1343,28 @@ def build_poster(
     else:
         genre_label = _GENRE_LABEL_OVERRIDES.get(genre, genre)
 
+    if cfg.hide_genre:
+        genre_label = ""
+        
+    # Resolve the info-sash pick once, regardless of whether the diagonal sash
+    # itself is rendered independently.
+    #
+    # When greyscale is active on an unreleased title (Cinema / Production),
+    # force the release-status slot to the front so its badge always wins — that
+    # tells the user the poster is greyscale because it's unavailable, rather
+    # than a title whose art happens to be black & white.
+    _sash_priority = cfg.sash_priority
+    if (cfg.cinema_greyscale and discovery_meta is not None
+            and discovery_meta.release_status in ("Cinema", "Production")):
+        _status = discovery_meta.release_status.lower()
+        if _status in _sash_priority or "release_status" in _sash_priority:
+            _sash_priority = [s for s in _sash_priority if s in ("release_status", _status)] + [s for s in _sash_priority if s not in ("release_status", _status)]
+    sash_result = (
+        pick_sash(discovery_meta, _sash_priority)
+        if discovery_meta is not None
+        else None
+    )
+
     # --- TOP GRADIENT (vectorised) ---
     # Darkens the top of the poster so the age-rating numeral and quality
     # badges stay legible over bright art.  Strength is one of four presets
@@ -1316,10 +1372,15 @@ def build_poster(
     # (height_ratio, max_alpha) tuple each level uses.  Unknown level is
     # treated as "high" rather than skipped so a typo in a URL doesn't
     # silently disable the vignette.
-    _tg_preset = _TOP_GRADIENT_LEVELS.get(cfg.top_gradient, _TOP_GRADIENT_LEVELS["high"])
-    if _tg_preset is not None:
+    _tg_preset: tuple[float, int] | None
+    if cfg.top_gradient == "custom" and cfg.top_gradient_opacity is not None and cfg.top_gradient_height is not None:
+        _tg_preset = (cfg.top_gradient_height, int(cfg.top_gradient_opacity * 255 if cfg.top_gradient_opacity <= 1.0 else cfg.top_gradient_opacity))
+    else:
+        _tg_preset = _TOP_GRADIENT_LEVELS.get(cfg.top_gradient, _TOP_GRADIENT_LEVELS["high"])
+        
+    if _tg_preset is not None and (not cfg.top_vignette_sash_only or sash_result is not None):
         top_height_ratio, top_max_alpha = _tg_preset
-        top_height = int(height * top_height_ratio)
+        top_height = max(1, int(height * top_height_ratio))
         t_top = np.linspace(0, 1, top_height, dtype=np.float32)
         eased_top = ((1 - t_top) * top_max_alpha).astype(np.uint8)
         top_array = np.broadcast_to(eased_top[:, np.newaxis], (top_height, width)).copy()
@@ -1336,10 +1397,14 @@ def build_poster(
     # like the lighter fade those modes used to get for free, pick "medium".
     # Unknown level falls back to "high" so a typo can't accidentally turn
     # the fade off entirely (which would break label legibility).
-    _bg_preset = _BOTTOM_GRADIENT_LEVELS.get(cfg.bottom_gradient, _BOTTOM_GRADIENT_LEVELS["high"])
+    if cfg.bottom_gradient == "custom" and cfg.bottom_gradient_opacity is not None and cfg.bottom_gradient_height is not None:
+        _bg_preset = (cfg.bottom_gradient_height, int(cfg.bottom_gradient_opacity * 255 if cfg.bottom_gradient_opacity <= 1.0 else cfg.bottom_gradient_opacity))
+    else:
+        _bg_preset = _BOTTOM_GRADIENT_LEVELS.get(cfg.bottom_gradient, _BOTTOM_GRADIENT_LEVELS["high"])
+        
     if _bg_preset is not None:
         bottom_height_ratio, bottom_max_alpha = _bg_preset
-        bottom_height = int(height * bottom_height_ratio)
+        bottom_height = max(1, int(height * bottom_height_ratio))
         bottom_start  = height - bottom_height
         t_bot         = np.linspace(0, 1, bottom_height, dtype=np.float32)
         eased_bot     = ((1 - (1 - t_bot) ** _BOTTOM_GRADIENT_CURVE) * bottom_max_alpha).astype(np.uint8)
@@ -1479,7 +1544,7 @@ def build_poster(
 
         def _line_width(text: str, current_font) -> int:
             bbox = draw.textbbox((0, 0), text, font=current_font)
-            return bbox[2] - bbox[0]
+            return int(bbox[2] - bbox[0])
 
         def _wrap_lines(text: str, current_font) -> list[str]:
             """Greedy word-wrap: each line packs as many words as fit within max_w."""
@@ -1565,7 +1630,7 @@ def build_poster(
             if scale < 1.0:
                 text_layer = text_layer.resize(
                     (max(1, int(text_layer.width * scale)), max(1, int(text_layer.height * scale))),
-                    Image.LANCZOS,
+                    Image.Resampling.LANCZOS,
                 )
 
             logo_x = round((width - text_layer.width) / 2)
@@ -1577,23 +1642,6 @@ def build_poster(
                 logo_y = int(centre_y - text_layer.height / 2)
             image.paste(text_layer, (logo_x, logo_y), text_layer)
 
-    # Resolve the info-sash pick once, regardless of whether the diagonal sash
-    # itself is rendered independently.
-    #
-    # When greyscale is active on an unreleased title (Cinema / Production),
-    # force the release-status slot to the front so its badge always wins — that
-    # tells the user the poster is greyscale because it's unavailable, rather
-    # than a title whose art happens to be black & white.
-    _sash_priority = cfg.sash_priority
-    if (cfg.cinema_greyscale and discovery_meta is not None
-            and discovery_meta.release_status in ("Cinema", "Production")
-            and "release_status" in _sash_priority):
-        _sash_priority = ["release_status"] + [s for s in _sash_priority if s != "release_status"]
-    sash_result = (
-        pick_sash(discovery_meta, _sash_priority)
-        if discovery_meta is not None
-        else None
-    )
 
     # --- Shared frosted tint (Match Notch Colour) ---------------------------
     # When the frosted rating bar (mode 4) and a poster-coloured sash element are
@@ -1646,13 +1694,13 @@ def build_poster(
                 sash_result if (_append_sash and sash_result) else (None, None)
             )
 
-            _pre_sash = [genre_label]
+            _pre_sash = [genre_label] if genre_label else []
             if _append_year and release_year:
                 _pre_sash.append(str(release_year))
             _label_main = " · ".join(_pre_sash)
 
             if _sash_text_for_label:
-                label = _label_main + " · " + translate_sash(_sash_text_for_label, cfg.logo_language)
+                label = _label_main + " · " + translate_sash(_sash_text_for_label, cfg.logo_language) if _label_main else translate_sash(_sash_text_for_label, cfg.logo_language)
             else:
                 label = _label_main
             rating_cy = height * cfg.accent_bar_y_offset
@@ -1689,7 +1737,7 @@ def build_poster(
                 _score_text = "10" if score >= 100 else f"{score / 10:.1f}"
             else:
                 _score_text = str(score)
-            label = f"{genre_label} ★ {_score_text}"
+            label = f"{genre_label} ★ {_score_text}" if genre_label else f"★ {_score_text}"
             rating_cy = height * cfg.numeric_score_y_offset
 
             try:
@@ -1726,18 +1774,18 @@ def build_poster(
             # Mode 1 ("Rating"): genre ★ score
             # Mode 2 ("Year + Rating"): genre [pip] year ★ score
             _has_score = score not in ("N/A", None)
-            parts = [(genre_label, None)]   # (text, separator_before)
+            parts = [(genre_label, None)] if genre_label else []
             if cfg.minimalist_append_mode == 0:
                 if release_year:
-                    parts.append((str(release_year), "rpip"))
+                    parts.append((str(release_year), "rpip" if parts else None))
             elif cfg.minimalist_append_mode == 1:
                 if _has_score:
-                    parts.append((str(score), "star"))
+                    parts.append((str(score), "star" if parts else None))
             else:  # 2 — Year + Rating
                 if release_year:
-                    parts.append((str(release_year), "pip"))
+                    parts.append((str(release_year), "pip" if parts else None))
                 if _has_score:
-                    parts.append((str(score), "star"))
+                    parts.append((str(score), "star" if parts else None))
 
             pip_gap = int(font_size * 0.55)
             pip_w   = max(4, int(font_size * 0.18))
@@ -1750,7 +1798,7 @@ def build_poster(
             ops    = []   # (kind, x[, text]); kind in text|pip|rpip|star
             for i in range(len(parts) - 1, -1, -1):
                 seg, sep = parts[i]
-                seg_x = cursor - draw.textlength(seg, font=font_meta)
+                seg_x = int(cursor - draw.textlength(seg, font=font_meta))
                 ops.append(("text", seg_x, seg))
                 cursor = seg_x
                 if sep:
@@ -2236,6 +2284,91 @@ def _seconds_until_next_hour(target_hour: float, now: float | None = None) -> fl
         target += 86400
     return target - now
 
+async def _run_trending_fetch_cycle(client: httpx.AsyncClient) -> None:
+    logger.info("Starting scheduled trending fetch cycle")
+    if not _cfg.SERVER_TMDB_KEY:
+        logger.info("Trending fetch: skipped - no server TMDB key configured")
+        return
+
+    try:
+        trending = await fetch_trending_candidates(
+            client, _cfg.SERVER_TMDB_KEY, max_items=max(_cfg.TRENDING_FETCH_COUNT, _cfg.TRENDING_BROAD_FETCH_COUNT)
+        )
+    except Exception as exc:
+        logger.error(f"Trending fetch: failed to fetch candidates: {exc}")
+        return
+
+    trending_items = {str(item.get("tmdb_id")) for item in trending}
+    if not trending_items:
+        return
+
+    db = get_db()
+    try:
+        rows = db.execute("SELECT cache_key, request_params FROM final_poster_cache WHERE request_params IS NOT NULL").fetchall()
+    except Exception as exc:
+        logger.error(f"Trending fetch: failed to query cache: {exc}")
+        return
+
+    # Use a test client to regenerate posters through the API
+    regenerated_count = 0
+    
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as local_client:
+        for cache_key, req_params_str in rows:
+            parts = cache_key.split(":")
+            if len(parts) >= 4:
+                tmdb_id = parts[1]
+                if tmdb_id in trending_items:
+                    logger.info(f"Trending fetch: regenerating poster for {cache_key}")
+                    try:
+                        delete_cached_final_poster(cache_key)
+                        await local_client.get(f"/poster?{req_params_str}")
+                        regenerated_count += 1
+                    except Exception as exc:
+                        logger.error(f"Trending fetch: failed to regenerate poster {cache_key}: {exc}")
+                    
+    logger.info(f"Trending fetch cycle completed. Regenerated {regenerated_count} posters.")
+
+
+async def _trending_fetch_loop() -> None:
+    """Periodically fetch trending items and regenerate cached posters."""
+    # First run immediately on startup
+    await asyncio.sleep(10)
+    try:
+        if _HTTP_CLIENT is not None:
+            await _run_trending_fetch_cycle(_HTTP_CLIENT)
+    except Exception as exc:
+        logger.error(f"Trending fetch: startup cycle failed: {exc}")
+
+    while True:
+        if not _cfg.TRENDING_FETCH_TIME:
+            wait = 86400.0
+        else:
+            try:
+                tz = zoneinfo.ZoneInfo(_cfg.TRENDING_FETCH_TIMEZONE)
+            except Exception as exc:
+                logger.error(f"Trending fetch: invalid timezone {_cfg.TRENDING_FETCH_TIMEZONE}: {exc}, using UTC")
+                tz = zoneinfo.ZoneInfo("UTC")
+
+            try:
+                h, m = map(int, _cfg.TRENDING_FETCH_TIME.split(':'))
+            except ValueError:
+                h, m = 0, 0
+                
+            now_dt = datetime.now(tz)
+            target_dt = now_dt.replace(hour=h, minute=m, second=0, microsecond=0)
+            if target_dt <= now_dt:
+                target_dt += timedelta(days=1)
+            wait = (target_dt - now_dt).total_seconds()
+            
+        logger.info(f"Trending fetch: next cycle scheduled in {wait / 3600:.1f} hours")
+        await asyncio.sleep(wait)
+        try:
+            if _HTTP_CLIENT is not None:
+                await _run_trending_fetch_cycle(_HTTP_CLIENT)
+        except Exception as exc:
+            logger.error(f"Trending fetch: cycle failed: {exc}")
+
 
 async def _cache_warm_loop(digital_release_ready: asyncio.Event | None = None) -> None:
     """
@@ -2376,10 +2509,12 @@ async def lifespan(app: FastAPI):
     prune_task   = asyncio.create_task(_cache_prune_loop())
     digital_task = asyncio.create_task(digital_release_poll_loop(_HTTP_CLIENT, _digital_release_ready))
     cache_warm_task = asyncio.create_task(_cache_warm_loop(_digital_release_ready))
+    trending_task = asyncio.create_task(_trending_fetch_loop())
     yield
     prune_task.cancel()
     digital_task.cancel()
     cache_warm_task.cancel()
+    trending_task.cancel()
     if _background_detection_task is not None:
         _background_detection_task.cancel()
     # Await the cancelled tasks so their finally: blocks finish unwinding
@@ -2390,6 +2525,8 @@ async def lifespan(app: FastAPI):
         await digital_task
     with suppress(asyncio.CancelledError):
         await cache_warm_task
+    with suppress(asyncio.CancelledError):
+        await trending_task
     if _background_detection_task is not None:
         with suppress(asyncio.CancelledError):
             await _background_detection_task
@@ -2476,6 +2613,7 @@ async def server_caps(access_key: str = ""):
             bool(_cfg.AIOSTREAMS_URL and _cfg.AIOSTREAMS_AUTH)
             or (_cfg.QUALITY_SOURCE == "scraper" and bool(_cfg.SCRAPER_URL))
         ),
+        "trending_fetch_count":  _cfg.TRENDING_FETCH_COUNT,
     }
 
 
@@ -2526,7 +2664,8 @@ def _compute_render_assets_signature() -> str:
 def _server_render_signature() -> str:
     return "|".join((
         f"render={_RENDER_CACHE_VERSION}",
-        f"jpeg={_cfg.JPEG_QUALITY}",
+        f"format={_cfg.IMAGE_FORMAT}",
+        f"quality={_cfg.WEBP_QUALITY if _cfg.IMAGE_FORMAT == 'webp' else _cfg.JPEG_QUALITY}",
         f"contrast={int(_cfg.LOGO_CONTRAST_RESCUE)}",
         f"stretch={int(_cfg.LOGO_STRETCH_DISABLED)}:{_cfg.LOGO_STRETCH_FACTOR:g}",
         f"assets={_render_assets_signature}",
@@ -2539,6 +2678,11 @@ def _load_configurator_html() -> str:
     try:
         with open(html_path, "r", encoding="utf-8") as f:
             content = f.read()
+
+        content = content.replace("{{TRENDING_FETCH_COUNT}}", str(_cfg.TRENDING_FETCH_COUNT))
+        content = content.replace("{{TRENDING_FETCH_COUNT_PLUS_ONE}}", str(_cfg.TRENDING_FETCH_COUNT + 1))
+        content = content.replace("{{TRENDING_BROAD_FETCH_COUNT}}", str(_cfg.TRENDING_BROAD_FETCH_COUNT))
+
         _configurator_etag = '"' + hashlib.md5(content.encode("utf-8")).hexdigest()[:16] + '"'
         return content
     except FileNotFoundError:
@@ -2621,7 +2765,7 @@ async def debug_canvas(genre: str = "Action", title: str = "Sample Title",
     cached = _debug_canvas_cache.get(cache_key)
     if cached is not None and now - cached[0] <= _DEBUG_CANVAS_TTL:
         return Response(
-            content=cached[1], media_type="image/jpeg",
+            content=cached[1], media_type=f"image/{_cfg.IMAGE_FORMAT}",
             headers={"Cache-Control": "private, max-age=300"},
         )
     gid = _DEBUG_GENRE_IDS.get(genre)
@@ -2633,14 +2777,14 @@ async def debug_canvas(genre: str = "Action", title: str = "Sample Title",
     img = build_poster(canvas, _score, genre, cfg, fallback_title=title,
                        release_year=(year or None), no_poster=True)
     buf = io.BytesIO()
-    img.convert("RGB").save(buf, format="JPEG", quality=90)
-    jpeg = buf.getvalue()
+    _quality = _cfg.WEBP_QUALITY if _cfg.IMAGE_FORMAT == "webp" else _cfg.JPEG_QUALITY
+    img.convert("RGB").save(buf, format=_cfg.IMAGE_FORMAT.upper(), quality=_quality)
+    data = buf.getvalue()
     if len(_debug_canvas_cache) >= _DEBUG_CANVAS_MAX_ENTRIES:
         oldest = min(_debug_canvas_cache, key=lambda key: _debug_canvas_cache[key][0])
         _debug_canvas_cache.pop(oldest, None)
-    _debug_canvas_cache[cache_key] = (now, jpeg)
     return Response(
-        content=jpeg, media_type="image/jpeg",
+        content=data, media_type=f"image/{_cfg.IMAGE_FORMAT}",
         headers={"Cache-Control": "private, max-age=300"},
     )
 
@@ -3000,7 +3144,7 @@ async def get_poster(
             etag = f'"{final_cache_key}"'
             if request.headers.get("if-none-match") == etag:
                 return Response(status_code=304)
-            _hit_resp = Response(content=cached_jpeg, media_type="image/jpeg")
+            _hit_resp = Response(content=cached_jpeg, media_type=f"image/{_cfg.IMAGE_FORMAT}")
             _hit_resp.headers["ETag"] = etag
             # This path is only reached when composite caching is enabled, so a
             # no-store branch would be dead here — CDN TTL is the only option.
@@ -3022,7 +3166,7 @@ async def get_poster(
         if _existing_fut is not None:
             logger.info(f"Coalescing request for {final_cache_key}")
             try:
-                _coal_resp = Response(content=await _existing_fut, media_type="image/jpeg")
+                _coal_resp = Response(content=await _existing_fut, media_type=f"image/{_cfg.IMAGE_FORMAT}")
                 _coal_resp.headers["ETag"] = f'"{final_cache_key}"'
                 # Coalescing only happens when caching is on (final_cache_key set),
                 # so no-store can't apply here — CDN TTL only.
@@ -3821,11 +3965,32 @@ async def get_poster(
         # ------------------------------------------------------------------
         _release_status: str | None = None
         _recent_digital_release_date: str | None = None
-        if "release_status" in rcfg.sash_priority:
-            _release_status = await fetch_release_status(
-                client, tmdb_id, effective_tmdb_key, type,
-                tmdb_data.get("tmdb_status"),
-            )
+        _rs_slots = {"release_status", "cinema", "streaming", "physical", "production", "ended", "cancelled"}
+        if any(s in rcfg.sash_priority for s in _rs_slots):
+            _fetch_rs = True
+            
+            import datetime
+            current_year = datetime.date.today().year
+            _check_year = None
+            
+            if type in ("tv", "series"):
+                _last_air = tmdb_data.get("last_air_date")
+                if _last_air and len(_last_air) >= 4 and _last_air[:4].isdigit():
+                    _check_year = _last_air[:4]
+                else:
+                    _check_year = release_year
+            else:
+                _check_year = release_year
+
+            if _check_year:
+                if (current_year - int(_check_year)) > _cfg.RELEASE_STATUS_MAX_AGE_YEARS:
+                    _fetch_rs = False
+            
+            if _fetch_rs:
+                _release_status = await fetch_release_status(
+                    client, tmdb_id, effective_tmdb_key, type,
+                    tmdb_data.get("tmdb_status"),
+                )
             # r/movieleaks confirmation overrides TMDB's theatrical/production
             # status — if the film is in the digital-release cache it's already
             # streaming regardless of what the official release dates say.
@@ -3972,7 +4137,8 @@ async def get_poster(
         def _composite_and_encode() -> bytes:
             result = build_poster(image, score, genre, rcfg, **_bp_args)
             buf = io.BytesIO()
-            result.convert("RGB").save(buf, format="JPEG", quality=_cfg.JPEG_QUALITY)
+            _quality = _cfg.WEBP_QUALITY if _cfg.IMAGE_FORMAT == "webp" else _cfg.JPEG_QUALITY
+            result.convert("RGB").save(buf, format=_cfg.IMAGE_FORMAT.upper(), quality=_quality)
             return buf.getvalue()
 
         img_bytes = await asyncio.get_running_loop().run_in_executor(
@@ -3989,13 +4155,24 @@ async def get_poster(
         #                            would evaluate False without this separate flag
         if (final_cache_key is not None and not quality_pending and not _detection_deferred
                 and not rating_failed and not _rating_backoff_active):
-            set_cached_final_poster(final_cache_key, img_bytes)
+            _ttl_override = None
+            if discovery_meta is not None:
+                _sash_result = pick_sash(discovery_meta, rcfg.sash_priority)
+                if _sash_result and _sash_result[1] in ("trending", "trending_broad"):
+                    _ttl_override = 86400
+                    
+            set_cached_final_poster(
+                final_cache_key, 
+                img_bytes, 
+                request_params=request.url.query, 
+                ttl_override=_ttl_override
+            )
             logger.info(f"Final poster cached for {final_cache_key}")
 
         if _render_fut is not None:
             _render_fut.set_result(img_bytes)
 
-        response = Response(content=img_bytes, media_type="image/jpeg")
+        response = Response(content=img_bytes, media_type=f"image/{_cfg.IMAGE_FORMAT}")
         if final_cache_key is not None:
             response.headers["ETag"] = f'"{final_cache_key}"'
         if _cfg.DISABLE_COMPOSITE_CACHE:
@@ -4013,7 +4190,7 @@ async def get_poster(
     except httpx.TimeoutException as exc:
         if _render_fut is not None and not _render_fut.done():
             _render_fut.set_exception(exc)
-        logger.warning(f"Upstream timeout for tmdb_id={tmdb_id}: {type(exc).__name__}")
+        logger.warning(f"Upstream timeout for tmdb_id={tmdb_id}: {exc.__class__.__name__}")
         raise HTTPException(status_code=504, detail="Upstream request timed out")
     except httpx.HTTPStatusError as exc:
         if _render_fut is not None and not _render_fut.done():

--- a/quality.py
+++ b/quality.py
@@ -7,7 +7,7 @@ import httpx
 logger = logging.getLogger(__name__)
 from PIL import Image, ImageDraw, ImageFont
 
-from awards import FETCH_FAILED
+from awards import FETCH_FAILED, _FetchFailed
 from cache import set_cached_quality
 from config import (
     AIOSTREAMS_AUTH,
@@ -399,7 +399,7 @@ def _warm_badge_cache(height: int) -> None:
             continue
         w, h = raw.size
         new_w = max(1, round(w * height / h))
-        _BADGE_CACHE[(token, height)] = raw.resize((new_w, height), Image.LANCZOS)
+        _BADGE_CACHE[(token, height)] = raw.resize((new_w, height), Image.Resampling.LANCZOS)
 
 
 def _init_badge_cache() -> None:
@@ -433,7 +433,7 @@ def get_resized_badge(token: str, height: int) -> Image.Image | None:
 
     w, h = raw.size
     new_w = max(1, round(w * height / h))
-    resized = raw.resize((new_w, height), Image.LANCZOS)
+    resized = raw.resize((new_w, height), Image.Resampling.LANCZOS)
     _BADGE_CACHE[key] = resized
     return resized
 
@@ -461,7 +461,7 @@ def _resize_premultiplied(img: Image.Image, size: tuple[int, int]) -> Image.Imag
     alpha = arr[..., 3:4] / 255.0                  # normalised alpha, H×W×1
     arr[..., :3] *= alpha                           # premultiply RGB
     pre = Image.fromarray(np.clip(arr, 0, 255).astype(np.uint8), "RGBA")
-    pre = pre.resize(size, Image.LANCZOS)
+    pre = pre.resize(size, Image.Resampling.LANCZOS)
     arr2 = np.array(pre, dtype=np.float32)
     alpha2 = arr2[..., 3:4] / 255.0
     nonzero = alpha2[..., 0] > 0
@@ -602,6 +602,6 @@ def render_badges_left(
             text_h = bb[3] - bb[1]
             ty = y_top + (badge_height - text_h) // 2
             draw.text((x, ty), label, font=_FALLBACK_FONT, fill=(255, 255, 255, 220))
-            x += (bb[2] - bb[0]) + badge_gap
+            x += int(bb[2] - bb[0]) + badge_gap
 
 

--- a/ratings.py
+++ b/ratings.py
@@ -405,7 +405,7 @@ def sample_frosted_bar_rgb(
     cy = max(0, bar_y); ch = min(bar_h, height - cy)
     reg = image.crop((0, cy, width, cy + ch))
     blr = reg.filter(ImageFilter.GaussianBlur(radius=max(6, int(bar_h * 0.45))))
-    th  = blr.resize((8, 8), Image.LANCZOS).convert("RGB")
+    th  = blr.resize((8, 8), Image.Resampling.LANCZOS).convert("RGB")
     ar  = np.array(th, dtype=np.float32)
     return float(ar[:, :, 0].mean()), float(ar[:, :, 1].mean()), float(ar[:, :, 2].mean())
 
@@ -481,13 +481,13 @@ def draw_frosted_bar(
         if tint_rgb is not None:
             dr, dg, db = tint_rgb
         else:
-            th  = blr.resize((8, 8), Image.LANCZOS).convert("RGB")
+            th  = blr.resize((8, 8), Image.Resampling.LANCZOS).convert("RGB")
             ar  = np.array(th, dtype=np.float32)
             dr, dg, db = ar[:,:,0].mean(), ar[:,:,1].mean(), ar[:,:,2].mean()
         _h2, _s2, _v2 = _cs.rgb_to_hsv(dr/255, dg/255, db/255)
         tr, tg, tb = _cs.hsv_to_rgb(_h2, min(1.0, _s2*1.2), _v2*0.4+0.60)
         r, g, b = int(tr*255*0.6+255*0.4), int(tg*255*0.6+255*0.4), int(tb*255*0.6+255*0.4)
-        base  = blr.resize((width, bar_h), Image.LANCZOS).convert("RGBA")
+        base  = blr.resize((width, bar_h), Image.Resampling.LANCZOS).convert("RGBA")
         frost = Image.new("RGBA", (width, bar_h), (r, g, b, int(frost_opacity*255)))
         return Image.alpha_composite(base, frost), _h2, _s2, _v2
 

--- a/tmdb.py
+++ b/tmdb.py
@@ -1146,6 +1146,8 @@ async def fetch_logo(
     return logo
 
 
+_trending_inflight: dict[str, asyncio.Event] = {}
+
 async def fetch_trending_rank(
     client: httpx.AsyncClient,
     tmdb_id: str,
@@ -1158,31 +1160,44 @@ async def fetch_trending_rank(
     snapshot = get_cached_trending_snapshot(endpoint)
 
     if snapshot is None:
-        logger.info("External API Call: Refreshing TMDB trending snapshot (pages 1-5 concurrent)")
+        inflight_event = _trending_inflight.get(endpoint)
+        if inflight_event is not None:
+            await inflight_event.wait()
+            snapshot = get_cached_trending_snapshot(endpoint)
+        
+        if snapshot is None:
+            event_to_set = asyncio.Event()
+            _trending_inflight[endpoint] = event_to_set
+            
+            try:
+                logger.info("External API Call: Refreshing TMDB trending snapshot (pages 1-5 concurrent)")
 
-        async def _fetch_page(page: int) -> list[dict]:
-            resp = await client.get(
-                f"https://api.themoviedb.org/3/trending/{endpoint}/day",
-                params={"api_key": tmdb_key, "page": page},
-            )
-            resp.raise_for_status()
-            return resp.json().get("results", [])
+                async def _fetch_page(page: int) -> list[dict]:
+                    resp = await client.get(
+                        f"https://api.themoviedb.org/3/trending/{endpoint}/day",
+                        params={"api_key": tmdb_key, "page": page},
+                    )
+                    resp.raise_for_status()
+                    return resp.json().get("results", [])
 
-        try:
-            pages = await asyncio.gather(*(_fetch_page(page) for page in range(1, 6)))
-        except Exception as exc:
-            logger.error(f"TMDB trending fetch error: {exc}")
-            return None
+                try:
+                    pages = await asyncio.gather(*(_fetch_page(page) for page in range(1, 6)))
+                except Exception as exc:
+                    logger.error(f"TMDB trending fetch error: {exc}")
+                    return None
 
-        rankings: dict[str, int] = {}
-        rank = 1
-        for results in pages:
-            for item in results:
-                rankings[str(item["id"])] = rank
-                rank += 1
+                rankings: dict[str, int] = {}
+                rank = 1
+                for results in pages:
+                    for item in results:
+                        rankings[str(item["id"])] = rank
+                        rank += 1
 
-        set_cached_trending_snapshot(endpoint, rankings)
-        snapshot = rankings
+                set_cached_trending_snapshot(endpoint, rankings)
+                snapshot = rankings
+            finally:
+                event_to_set.set()
+                _trending_inflight.pop(endpoint, None)
 
     rank = snapshot.get(str(tmdb_id))
 
@@ -1536,6 +1551,36 @@ def _parse_tmdb_date(value: str | None) -> _date | None:
         return None
 
 
+def _compute_movie_status_from_dates(
+    theatrical_date: _date | None,
+    digital_date: _date | None,
+    physical_date: _date | None,
+    tmdb_status: str | None,
+) -> str:
+    today = _date.today()
+    has_physical = physical_date is not None and physical_date <= today
+    has_digital = digital_date is not None and digital_date <= today
+    has_theatrical = theatrical_date is not None and theatrical_date <= today
+
+    if has_physical:
+        return "Physical"
+    elif has_digital:
+        return "Streaming"
+    elif has_theatrical:
+        if (
+            CINEMA_MAX_AGE_YEARS > 0
+            and theatrical_date is not None
+            and (today - theatrical_date).days > CINEMA_MAX_AGE_YEARS * 365
+        ):
+            return "Streaming"
+        else:
+            return "Cinema"
+    elif tmdb_status == "Released":
+        return "Streaming"
+    else:
+        return "Production"
+
+
 async def fetch_movie_release_info(
     client: httpx.AsyncClient,
     tmdb_id: str,
@@ -1546,6 +1591,12 @@ async def fetch_movie_release_info(
     cache_key = f"movie_{tmdb_id}"
     cached = get_cached_movie_release_info(cache_key)
     if cached:
+        cached["status"] = _compute_movie_status_from_dates(
+            _parse_tmdb_date(cached.get("theatrical_date")),
+            _parse_tmdb_date(cached.get("digital_date")),
+            _parse_tmdb_date(cached.get("physical_date")),
+            tmdb_status,
+        )
         return cached
 
     result: str | None = None
@@ -1587,38 +1638,24 @@ async def fetch_movie_release_info(
         for rd in entry.get("release_dates", []):
             rtype = rd.get("type")
             rdate = _parse_tmdb_date(rd.get("release_date"))
-            if rdate is None or rdate > today:
+            if rdate is None:
                 continue
             if rtype == 5:
-                has_physical = True
                 if latest_physical is None or rdate > latest_physical:
                     latest_physical = rdate
             elif rtype in (4, 6):   # digital or TV broadcast
-                has_digital = True
                 if latest_digital is None or rdate > latest_digital:
                     latest_digital = rdate
             elif rtype == 3:
-                has_theatrical = True
                 if earliest_theatrical is None or rdate < earliest_theatrical:
                     earliest_theatrical = rdate
 
-    if has_physical:
-        result = "Physical"
-    elif has_digital:
-        result = "Streaming"
-    elif has_theatrical:
-        if (
-            CINEMA_MAX_AGE_YEARS > 0
-            and earliest_theatrical is not None
-            and (today - earliest_theatrical).days > CINEMA_MAX_AGE_YEARS * 365
-        ):
-            result = "Streaming"
-        else:
-            result = "Cinema"
-    elif tmdb_status == "Released":
-        result = "Streaming"
-    else:
-        result = "Production"
+    result = _compute_movie_status_from_dates(
+        earliest_theatrical,
+        latest_digital,
+        latest_physical,
+        tmdb_status,
+    )
 
     info = {
         "status": result,

--- a/tmdb.py
+++ b/tmdb.py
@@ -76,7 +76,7 @@ def normalise_poster(image: Image.Image) -> Image.Image:
     scale = max(target_w / src_w, target_h / src_h)
     new_w = round(src_w * scale)
     new_h = round(src_h * scale)
-    image = image.resize((new_w, new_h), Image.LANCZOS)
+    image = image.resize((new_w, new_h), Image.Resampling.LANCZOS)
     left = round((new_w - target_w) / 2)
     top  = round((new_h - target_h) / 2)
     return image.crop((left, top, left + target_w, top + target_h))
@@ -730,7 +730,7 @@ def _saliency_crop_left(image: Image.Image, crop_w: int,
     sh      = max(1, int(h * scale))
     scrop_w = max(1, int(crop_w * scale))
 
-    small = image.resize((sw, sh), Image.LANCZOS).convert("RGB")
+    small = image.resize((sw, sh), Image.Resampling.LANCZOS).convert("RGB")
     rgb   = np.array(small, dtype=np.float32) / 255.0   # H × W × 3, [0,1]
     r, g, b = rgb[:,:,0], rgb[:,:,1], rgb[:,:,2]
 
@@ -1688,7 +1688,7 @@ async def fetch_release_status(
             "In Production":    "Production",
             "Planned":          "Production",
             "Pilot":            "Production",
-            "Ended":            "Streaming",  # completed run → assume available on streaming
+            "Ended":            "Ended",
             "Cancelled":        "Cancelled",
             "Canceled":         "Cancelled",
         }
@@ -1791,7 +1791,7 @@ def composite_logo(
             f"max_h={max_h} eff_max_h={eff_max_h:.0f} → final={int(new_w)}x{int(new_h)}"
         )
 
-    logo = logo.resize((max(1, int(new_w)), max(1, int(new_h))), Image.LANCZOS)
+    logo = logo.resize((max(1, int(new_w)), max(1, int(new_h))), Image.Resampling.LANCZOS)
 
     # ── Position ─────────────────────────────────────────────────────────────
     # Two anchor modes:


### PR DESCRIPTION
-Added option to only display vignette when sash is present.
-Added custom granular vignette controls.
-Separated short/binge/mini and release status items into individual toggles.
-Added hide genre toggle to ratings page.
-Added 'Ended' sash display value.
-Changed how trending data is fetched by getting the trending list daily and immediately regenerating the posters for items on the list. This required altering the cache structure so that items on the trending list can be regenerated in all used configurations.
-Time and timezone for daily trending fetch configurable from env, if not set uses a 24h timer. Next refresh info is displayed in configurator.
-The number of items to fetch for the trending list (standard and broad) is now configurable through the env file, the configurator options update to reflect the new numbers.
-Release status is now only applied to items whose release date (movies) or last air date (shows) was in the last 5 years - timeframe configurable in env file.
-Posters are rechecked and replaced (if different) for titles when they go from production to release.
-The preview window now moves to the top of the page when users have scrolled to the bottom when using the configurator on mobile (avoids covering buttons).
-Composited posters are now stored as webp files by default for storage efficiency and delivery speed. Jpeg can still be used by selecting in the env file.
-Updated how new season sash is evaluated to handle multi episode drops