### PR TITLE
Add MDBList-free rating sources: direct TMDB vote average + local IMDb dataset

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,7 +14,17 @@
 # Get one free at https://www.themoviedb.org/settings/api
 TMDB_API_KEY=
 
-# [Required] Fetches aggregated ratings and keywords.
+# Fetches aggregated ratings (Letterboxd, Trakt, Rotten Tomatoes, Metacritic,
+# IMDb, ...), keywords (used for the festival/cult/true-story/must-see sashes
+# and Oscar detection), and age ratings.
+# Optional despite the name suggesting otherwise in earlier docs: leaving this
+# blank does not stop the app from running. Posters still render with genre,
+# year, TMDB-sourced sashes (trending, Golden Globe, studio/director/cast,
+# foreign-language, release-status, structural), and quality badges; only the
+# MDBList-only sashes (festival, cult classic, true story, Metacritic
+# must-see, Oscar wins/noms) and the weighted rating score are unavailable,
+# and the score reads "N/A" unless IMDB_DATASET_ENABLED supplies the "imdb"
+# weight from the local dataset below instead.
 # Get one free at https://mdblist.com/
 MDBLIST_API_KEY=
 
@@ -110,6 +120,31 @@ QUALITY_WAIT_TIMEOUT=30
 
 # Max concurrent outbound MDBList calls per worker.
 MDBLIST_CONCURRENCY=3
+
+# =============================================================================
+# IMDb local ratings dataset (MDBList-free IMDb score)
+# =============================================================================
+
+# Every weighted rating source, including the one labelled "imdb", normally
+# comes from MDBList. Enabling this pulls IMDb's own free, no-key,
+# daily-refreshed non-commercial dataset instead
+# (https://datasets.imdbws.com/title.ratings.tsv.gz) and answers "imdb" weight
+# lookups from a local table — no MDBList key needed for that source, and it
+# still works if you have no MDBList key configured at all. Select it per
+# instance/request with imdb_rating_source=dataset (default: mdblist,
+# unchanged behaviour). Off by default.
+IMDB_DATASET_ENABLED=false
+
+# Where the downloaded dataset is stored (SQLite file). Put it on the same
+# persistent volume as the rest of the cache.
+IMDB_DATASET_PATH=/app/cache/imdb_ratings.db
+
+# Hours between dataset refreshes. IMDb regenerates the source file about once
+# a day, so anything below 24 just re-downloads the same data.
+IMDB_DATASET_REFRESH_HOURS=24
+
+# Minimum vote count for a dataset rating to be used, mirroring RATING_MIN_VOTES.
+IMDB_DATASET_MIN_VOTES=10
 
 # =============================================================================
 # Output format and caching

--- a/ADVANCED.md
+++ b/ADVANCED.md
@@ -115,6 +115,55 @@ Default: `false`
 
 ---
 
+## Ratings without MDBList
+
+Every weighted rating source normally comes from MDBList — including the one
+labelled "tmdb". Two of them can instead be sourced without an MDBList key at
+all, if that's all you need:
+
+### `imdb_rating_source` (URL param) / `IMDB_DATASET_ENABLED` (env)
+
+Sources the IMDb weight from IMDb's own free, no-key, daily-refreshed
+non-commercial dataset (`https://datasets.imdbws.com/title.ratings.tsv.gz`)
+instead of MDBList. Set `IMDB_DATASET_ENABLED=true` on the server, then select
+it with `imdb_rating_source=dataset` (default: `mdblist`, unchanged
+behaviour) — also available as a dropdown on the configurator's Weights tab.
+
+A background task downloads and reloads the full dataset into a local SQLite
+table on `IMDB_DATASET_REFRESH_HOURS` (default 24 — IMDb itself only
+regenerates the file about once a day, so refreshing faster buys nothing).
+Lookups are a single indexed local query, not a network call.
+`IMDB_DATASET_MIN_VOTES` (default 10) filters out titles with too few votes to
+be meaningful, mirroring `RATING_MIN_VOTES`. `IMDB_DATASET_PATH` (default
+`/app/cache/imdb_ratings.db`) is where the table lives — keep it on the same
+volume as the rest of the cache so it survives restarts.
+
+If a live MDBList fetch fails for a title, the IMDb dataset value (when
+enabled) is still tried before giving up, so an MDBList outage doesn't
+unconditionally zero out the score for operators using this.
+
+Default: `IMDB_DATASET_ENABLED=false`, `IMDB_DATASET_REFRESH_HOURS=24`,
+`IMDB_DATASET_MIN_VOTES=10`, `IMDB_DATASET_PATH=/app/cache/imdb_ratings.db`
+
+### `tmdb_rating_source` (URL param)
+
+Sources the TMDB weight from TMDB's own `vote_average` — already fetched in
+the same metadata call used for genre, year, and credits — instead of
+MDBList. Set `tmdb_rating_source=direct` (default: `mdblist`, unchanged
+behaviour). No env var or background task needed; the value is already in
+hand on every request, so this has no extra cost. Also available as a
+dropdown on the Weights tab.
+
+Between the two, an instance can run entirely without an MDBList key: TMDB
+metadata (genre, year), TMDB-only sashes (trending, Golden Globe,
+studio/director/cast, foreign-language, release-status), and both the TMDB
+and IMDb weighted ratings. What you lose without MDBList is the MDBList-only
+sashes (festival, cult classic, true story, Metacritic must-see, Oscar
+wins/nominations) and every other weighted rating source (Letterboxd, Trakt,
+Rotten Tomatoes, Metacritic, Popcornmeter, Roger Ebert).
+
+---
+
 ## Cache warming
 
 ### `CACHE_WARM_AT_HOUR`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,26 @@
   repeated at each call site. `/status` reports the active backend as
   `quality_source`.
 
+### Ratings
+
+- Added an MDBList-free way to source two of the weighted rating inputs.
+  `tmdb_rating_source=direct` uses TMDB's own vote average — already fetched
+  alongside genre/year/credits, so it costs nothing extra and needs no MDBList
+  key. `imdb_rating_source=dataset` sources the IMDb weight from IMDb's own
+  free, no-key, daily-refreshed non-commercial dataset
+  (`title.ratings.tsv.gz`), downloaded and refreshed on a schedule
+  (`IMDB_DATASET_ENABLED`, `IMDB_DATASET_REFRESH_HOURS`,
+  `IMDB_DATASET_MIN_VOTES`, `IMDB_DATASET_PATH`) and looked up locally with no
+  per-title network call. Both default to the existing MDBList-sourced
+  behaviour and are exposed as dropdowns on the Weights tab. Either can be
+  used with zero MDBList key configured, and the IMDb dataset value is also
+  tried as a fallback when a live MDBList fetch fails, so a MDBList outage no
+  longer means an unconditional `N/A` score for operators who enable it.
+- Corrected `.env.example`'s `MDBLIST_API_KEY` documentation, which called it
+  `[Required]`; it has been optional in the request path for some time (see
+  the "IMDb ids are now optional" entry above) and is now spelled out exactly
+  which sashes and the score are unavailable without it.
+
 ### Metadata And Caching
 
 - IMDb ids are now optional. `tmdb_id` is the required identity — it selects the

--- a/cache.py
+++ b/cache.py
@@ -303,6 +303,7 @@ def init_db() -> None:
         ("backdrop_path",       "TEXT"),
         ("tmdb_status",         "TEXT"),
         ("vote_count",          "INTEGER"),
+        ("vote_average",        "REAL"),
         ("text_backdrop_path",  "TEXT"),
         ("original_poster_path","TEXT"),
         ("poster_langs_json",   "TEXT"),
@@ -1221,6 +1222,7 @@ def get_cached_tmdb_metadata(cache_key: str) -> dict | None:
                    credits_json, production_cos_json,
                    runtime, number_of_seasons, number_of_episodes,
                    original_language, original_title, backdrop_path, tmdb_status, vote_count,
+                   vote_average,
                    text_backdrop_path, original_poster_path,
                    poster_langs_json, imdb_id,
                    tmdb_release_date, last_air_date, next_episode_json,
@@ -1239,6 +1241,7 @@ def get_cached_tmdb_metadata(cache_key: str) -> dict | None:
             credits_json, production_cos_json,
             runtime, number_of_seasons, number_of_episodes,
             original_language, original_title, backdrop_path, tmdb_status, vote_count,
+            vote_average,
             text_backdrop_path, original_poster_path,
             poster_langs_json, imdb_id,
             tmdb_release_date, last_air_date, next_episode_json,
@@ -1282,7 +1285,7 @@ def get_cached_tmdb_metadata(cache_key: str) -> dict | None:
         # Rows created before newer metadata fields were added were migrated
         # with NULL. Refresh once so discovery sashes have complete title,
         # vote, and TV lifecycle fields.
-        if vote_count is None or original_title is None or metadata_version != 3:
+        if vote_count is None or original_title is None or metadata_version != 4:
             logger.info(
                 f"TMDB metadata cache missing current schema fields for {cache_key}; refreshing"
             )
@@ -1310,6 +1313,7 @@ def get_cached_tmdb_metadata(cache_key: str) -> dict | None:
             "backdrop_path":        backdrop_path,
             "tmdb_status":          tmdb_status,
             "vote_count":           vote_count,
+            "vote_average":         vote_average,
             "text_backdrop_path":   text_backdrop_path,
             "original_poster_path": original_poster_path,
             "poster_langs":         json.loads(poster_langs_json or "{}"),
@@ -1345,6 +1349,7 @@ def set_cached_tmdb_metadata(
     backdrop_path: str | None = None,
     tmdb_status: str | None = None,
     vote_count: int | None = None,
+    vote_average: float | None = None,
     text_backdrop_path: str | None = None,
     original_poster_path: str | None = None,
     poster_langs: dict | None = None,
@@ -1354,7 +1359,7 @@ def set_cached_tmdb_metadata(
     next_episode: dict | None = None,
     last_episode: dict | None = None,
     seasons: list[dict] | None = None,
-    metadata_version: int = 3,
+    metadata_version: int = 4,
 ) -> None:
     try:
         with _db_lock:
@@ -1366,11 +1371,12 @@ def set_cached_tmdb_metadata(
                      credits_json, production_cos_json,
                      runtime, number_of_seasons, number_of_episodes,
                      original_language, original_title, backdrop_path, tmdb_status, vote_count,
+                     vote_average,
                      text_backdrop_path, original_poster_path,
                      poster_langs_json, imdb_id,
                      tmdb_release_date, last_air_date, next_episode_json,
                      last_episode_json, seasons_json, metadata_version)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     cache_key,
@@ -1391,6 +1397,7 @@ def set_cached_tmdb_metadata(
                     backdrop_path,
                     tmdb_status,
                     vote_count,
+                    vote_average,
                     text_backdrop_path,
                     original_poster_path,
                     json.dumps(poster_langs or {}),

--- a/config.py
+++ b/config.py
@@ -298,6 +298,24 @@ QUALITY_WAIT_TIMEOUT         = float(os.environ.get("QUALITY_WAIT_TIMEOUT", "30"
 # apparent per-key concurrency limit while still allowing good parallelism.
 MDBLIST_CONCURRENCY          = int(os.environ.get("MDBLIST_CONCURRENCY", "3"))
 
+# -----------------------------------------------------------------------
+# IMDb local ratings dataset — an MDBList-free way to source the "imdb"
+# weight, pulled straight from IMDb's own free, no-key, daily-refreshed
+# non-commercial dataset (https://datasets.imdbws.com/title.ratings.tsv.gz).
+#
+# Off by default. When enabled, a background task downloads the dataset on
+# IMDB_DATASET_REFRESH_HOURS and answers lookups from a local SQLite table —
+# no per-title network call, no MDBList key required for that source. See
+# imdb_dataset.py. Selected per-request/per-instance via the "imdb" weight's
+# source setting (imdb_rating_source=dataset), independent of MDBList.
+# -----------------------------------------------------------------------
+IMDB_DATASET_ENABLED         = os.environ.get("IMDB_DATASET_ENABLED", "false").strip().lower() in ("1", "true", "yes")
+IMDB_DATASET_PATH            = os.environ.get("IMDB_DATASET_PATH", "/app/cache/imdb_ratings.db").strip()
+IMDB_DATASET_REFRESH_HOURS   = max(1, int(os.environ.get("IMDB_DATASET_REFRESH_HOURS", "24")))
+# IMDb's own dataset already includes titles with a single vote; this filters
+# those out for the same reason RATING_MIN_VOTES exists for MDBList sources.
+IMDB_DATASET_MIN_VOTES       = max(0, int(os.environ.get("IMDB_DATASET_MIN_VOTES", "10")))
+
 # Cache warming — proactively populate the TMDB metadata cache (logos, posters,
 # credits) and the MDBList rating/award cache for currently-trending titles, so
 # the first real requests for them are fast and don't all hit upstream APIs at

--- a/configurator.html
+++ b/configurator.html
@@ -3125,6 +3125,22 @@ try{if(localStorage.getItem('postersplus_theme')==='light')document.documentElem
               </label>
             </div>
 
+            <div class="field" id="imdb-rating-source-field">
+              <label class="field-label" data-tip="Every other weighted source (Letterboxd, Trakt, Rotten Tomatoes, Metacritic, ...) always comes from MDBList. The IMDb weight can instead be sourced locally from IMDb's own free daily dataset, which needs no MDBList key and isn't subject to MDBList's rate limits. Requires IMDB_DATASET_ENABLED=true on the server.">IMDb Rating Source</label>
+              <select id="cfg-imdb-rating-source" onchange="build(); queuePreviewReload()">
+                <option value="mdblist" selected>MDBList (default)</option>
+                <option value="dataset">Local IMDb dataset (no MDBList key needed)</option>
+              </select>
+            </div>
+
+            <div class="field" id="tmdb-rating-source-field">
+              <label class="field-label" data-tip="Every source MDBList aggregates, including the one labelled TMDB, currently comes through MDBList. This sources the TMDB weight directly from TMDB's own vote average instead — it's already fetched for genre/year, so this costs nothing extra and needs no MDBList key.">TMDB Rating Source</label>
+              <select id="cfg-tmdb-rating-source" onchange="build(); queuePreviewReload()">
+                <option value="mdblist" selected>MDBList (default)</option>
+                <option value="direct">Direct from TMDB (no MDBList key needed)</option>
+              </select>
+            </div>
+
             <div class="cfg-sep">
               <span class="group-title" data-tip="Normalization always reaches 100%. 99% Letterboxd + 1% Trakt becomes 100% Trakt if Letterboxd is missing.">Movies</span>
               <div class="weight-grid" id="movie-weights"></div>
@@ -4505,6 +4521,8 @@ function buildBaseParams({ usePlaceholders = false, domainOverride = null } = {}
     } }
   if (c('tog-hide-genre')) params.set('hide_genre', 'true');
   params.set('fallback_to_imdb', c('tog-fallback-imdb') ? 'true' : 'false');
+  params.set('imdb_rating_source', vEl('cfg-imdb-rating-source') || 'mdblist');
+  params.set('tmdb_rating_source', vEl('cfg-tmdb-rating-source') || 'mdblist');
 
   // ── Rating / Genre Label ───────────────────────────────────────────────────
   params.set('rating_display_mode', ratingMode);
@@ -5633,6 +5651,8 @@ function importUrl(urlStr, { silent = false, settingsOnly = false, preserveClien
   if (p.has('stremio_id') || p.has('anilist_id') || p.has('kitsu_id')) _setEl('tog-anime-ids', 'true');
   updateGradientFields();
   if (p.has('fallback_to_imdb')) _setEl('tog-fallback-imdb', p.get('fallback_to_imdb'));
+  if (p.has('imdb_rating_source')) _setEl('cfg-imdb-rating-source', p.get('imdb_rating_source'));
+  if (p.has('tmdb_rating_source')) _setEl('cfg-tmdb-rating-source', p.get('tmdb_rating_source'));
 
   // ── Sash ────────────────────────────────────────────────────────────────
   if (p.has('sash_poster_color')) _setEl('tog-sash-poster-color', p.get('sash_poster_color'));

--- a/imdb_dataset.py
+++ b/imdb_dataset.py
@@ -1,0 +1,252 @@
+#imdb_dataset.py
+"""
+Local IMDb ratings source, sourced from IMDb's own non-commercial datasets
+(https://datasets.imdbws.com/title.ratings.tsv.gz) rather than MDBList.
+
+Why this exists: every rating PostersPlus can weight — including the one
+labelled "imdb" — currently comes from a single MDBList API call per title.
+That is fine for the many sources MDBList aggregates (Letterboxd, Trakt,
+Rotten Tomatoes, Metacritic, ...), which have no public bulk-download route.
+IMDb is the one exception: IMDb itself publishes a free, no-key-required,
+daily-refreshed TSV of every title's aggregate rating and vote count. An
+operator who only cares about the IMDb score does not need an MDBList key
+(or its rate limits) at all to get one.
+
+This module downloads that TSV on a schedule, loads it into a small SQLite
+table keyed on the IMDb id (tconst), and answers point lookups from it. It
+never makes a per-title network call — the whole dataset is pulled in one
+shot on a timer, matching the pattern digital_release.py uses for its own
+periodic background sync.
+
+Enabled with IMDB_DATASET_ENABLED=true. Fully inert (no download, no table,
+lookups always return None) when disabled — the default.
+"""
+import asyncio
+import gzip
+import io
+import logging
+import os
+import sqlite3
+import threading
+import time
+
+import httpx
+
+from config import (
+    IMDB_DATASET_ENABLED,
+    IMDB_DATASET_PATH,
+    IMDB_DATASET_REFRESH_HOURS,
+    IMDB_DATASET_MIN_VOTES,
+)
+
+logger = logging.getLogger(__name__)
+
+_DATASET_URL = "https://datasets.imdbws.com/title.ratings.tsv.gz"
+
+_local = threading.local()
+_initialised = False
+_last_refresh_ts: float | None = None
+_last_refresh_rows: int = 0
+_last_refresh_error: str | None = None
+
+
+def is_enabled() -> bool:
+    return bool(IMDB_DATASET_ENABLED)
+
+
+def _get_db() -> sqlite3.Connection:
+    conn = getattr(_local, "conn", None)
+    if conn is None:
+        os.makedirs(os.path.dirname(IMDB_DATASET_PATH) or ".", exist_ok=True)
+        conn = sqlite3.connect(IMDB_DATASET_PATH, check_same_thread=False)
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS imdb_ratings (
+                tconst  TEXT PRIMARY KEY,
+                rating  REAL NOT NULL,
+                votes   INTEGER NOT NULL
+            )
+        """)
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS imdb_ratings_meta (
+                key   TEXT PRIMARY KEY,
+                value TEXT
+            )
+        """)
+        conn.commit()
+        _local.conn = conn
+    return conn
+
+
+def init_db() -> None:
+    """Idempotent — safe to call once at startup even when disabled, so the
+    file exists and later enabling the feature needs no migration step."""
+    global _initialised
+    if not is_enabled():
+        return
+    _get_db()
+    _initialised = True
+
+
+def status() -> dict:
+    return {
+        "enabled": is_enabled(),
+        "path": IMDB_DATASET_PATH if is_enabled() else None,
+        "refresh_hours": IMDB_DATASET_REFRESH_HOURS,
+        "min_votes": IMDB_DATASET_MIN_VOTES,
+        "last_refresh_unix": _last_refresh_ts,
+        "last_refresh_rows": _last_refresh_rows,
+        "last_refresh_error": _last_refresh_error,
+        "row_count": row_count() if is_enabled() else 0,
+    }
+
+
+def row_count() -> int:
+    if not is_enabled():
+        return 0
+    try:
+        conn = _get_db()
+        return conn.execute("SELECT COUNT(*) FROM imdb_ratings").fetchone()[0]
+    except Exception:
+        return 0
+
+
+def get_rating(imdb_id: str | None) -> float | None:
+    """Return the 0-10 average rating for *imdb_id*, or None if unknown /
+    below IMDB_DATASET_MIN_VOTES / the feature is disabled.
+
+    Synchronous — this is a single indexed SQLite lookup (sub-millisecond),
+    not a network call, so it is safe to call inline from the request path.
+    """
+    if not is_enabled() or not imdb_id:
+        return None
+    try:
+        conn = _get_db()
+        row = conn.execute(
+            "SELECT rating, votes FROM imdb_ratings WHERE tconst = ?",
+            (imdb_id,),
+        ).fetchone()
+    except Exception as exc:
+        logger.warning(f"IMDb dataset lookup failed for {imdb_id}: {exc}")
+        return None
+    if row is None:
+        return None
+    rating, votes = row
+    if votes < IMDB_DATASET_MIN_VOTES:
+        return None
+    return float(rating)
+
+
+async def refresh_dataset(client: httpx.AsyncClient) -> int:
+    """Download and reload the full dataset. Returns the row count loaded.
+
+    Runs the download+parse+bulk-insert off the event loop (it's a ~25 MB
+    gzip download and a few million-row parse) so it never blocks request
+    handling; only the final connection handoff happens on this thread.
+    """
+    global _last_refresh_ts, _last_refresh_rows, _last_refresh_error
+
+    if not is_enabled():
+        return 0
+
+    try:
+        resp = await client.get(_DATASET_URL, timeout=120.0)
+        resp.raise_for_status()
+        raw = resp.content
+    except Exception as exc:
+        _last_refresh_error = f"download failed: {exc}"
+        logger.error(f"IMDb dataset download failed: {exc}")
+        return 0
+
+    def _parse_and_load() -> int:
+        rows: list[tuple[str, float, int]] = []
+        with gzip.GzipFile(fileobj=io.BytesIO(raw)) as gz:
+            text = io.TextIOWrapper(gz, encoding="utf-8")
+            header = text.readline()  # tconst  averageRating  numVotes
+            for line in text:
+                parts = line.rstrip("\n").split("\t")
+                if len(parts) != 3:
+                    continue
+                tconst, rating_str, votes_str = parts
+                try:
+                    rating = float(rating_str)
+                    votes = int(votes_str)
+                except ValueError:
+                    continue
+                rows.append((tconst, rating, votes))
+
+        conn = sqlite3.connect(IMDB_DATASET_PATH, check_same_thread=False)
+        try:
+            conn.execute("PRAGMA journal_mode=WAL")
+            conn.execute("""
+                CREATE TABLE IF NOT EXISTS imdb_ratings (
+                    tconst  TEXT PRIMARY KEY,
+                    rating  REAL NOT NULL,
+                    votes   INTEGER NOT NULL
+                )
+            """)
+            conn.execute("""
+                CREATE TABLE IF NOT EXISTS imdb_ratings_meta (
+                    key   TEXT PRIMARY KEY,
+                    value TEXT
+                )
+            """)
+            # Load into a fresh table and swap it in, so concurrent readers on
+            # other connections never see a half-populated table mid-refresh.
+            conn.execute("DROP TABLE IF EXISTS imdb_ratings_new")
+            conn.execute("""
+                CREATE TABLE imdb_ratings_new (
+                    tconst  TEXT PRIMARY KEY,
+                    rating  REAL NOT NULL,
+                    votes   INTEGER NOT NULL
+                )
+            """)
+            conn.execute("BEGIN")
+            conn.executemany(
+                "INSERT INTO imdb_ratings_new (tconst, rating, votes) VALUES (?, ?, ?)",
+                rows,
+            )
+            conn.execute("DROP TABLE imdb_ratings")
+            conn.execute("ALTER TABLE imdb_ratings_new RENAME TO imdb_ratings")
+            conn.execute(
+                "INSERT OR REPLACE INTO imdb_ratings_meta (key, value) VALUES ('last_refresh', ?)",
+                (str(int(time.time())),),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+        return len(rows)
+
+    try:
+        loop = asyncio.get_running_loop()
+        count = await loop.run_in_executor(None, _parse_and_load)
+    except Exception as exc:
+        _last_refresh_error = f"parse/load failed: {exc}"
+        logger.error(f"IMDb dataset parse/load failed: {exc}")
+        return 0
+
+    # Any per-thread connections opened before the swap point at a now-stale
+    # schema object; drop the cached handle on this thread so the next lookup
+    # reconnects and sees the new table.
+    _local.conn = None
+
+    _last_refresh_ts = time.time()
+    _last_refresh_rows = count
+    _last_refresh_error = None
+    logger.info(f"IMDb dataset refreshed: {count} titles loaded from {_DATASET_URL}")
+    return count
+
+
+async def imdb_dataset_refresh_loop(client: httpx.AsyncClient) -> None:
+    """Background task: refresh shortly after startup, then every
+    IMDB_DATASET_REFRESH_HOURS. IMDb regenerates this file once a day, so
+    refreshing more often than that buys nothing."""
+    if not is_enabled():
+        return
+    await asyncio.sleep(30)  # let the service finish warming up first
+    while True:
+        try:
+            await refresh_dataset(client)
+        except Exception as exc:
+            logger.error(f"IMDb dataset refresh loop error: {exc}")
+        await asyncio.sleep(max(1, IMDB_DATASET_REFRESH_HOURS) * 3600)

--- a/main.py
+++ b/main.py
@@ -580,6 +580,8 @@ from cache import (
     get_db,
 )
 from digital_release import digital_release_poll_loop
+import imdb_dataset
+from imdb_dataset import imdb_dataset_refresh_loop
 import config as _cfg
 from discovery import (
     ALL_PRIORITY_SLOTS,
@@ -714,6 +716,65 @@ def _canonical_rating_id(imdb_id: str, anime_key: str, tmdb_id: str) -> str:
     so no migration is needed.
     """
     return imdb_id or anime_key or f"tmdb:{tmdb_id}"
+
+
+def _merge_imdb_dataset_rating(
+    ratings_dict, effective_imdb_id: str | None, rcfg: "RequestConfig"
+):
+    """Override the "imdb" entry in *ratings_dict* with a value looked up from
+    the local IMDb dataset, when the request/instance is configured to source
+    it that way.
+
+    A no-op (returns *ratings_dict* unchanged) unless all of: the feature is
+    enabled server-side, the config asked for "dataset" rather than the
+    default "mdblist", a real IMDb id is available, and that id is present in
+    the dataset with enough votes. In every no-op case the existing MDBList
+    behaviour (if any) is left exactly as it was — this only ever adds or
+    replaces the single "imdb" key, and only when it has something to put
+    there. That also means it works with no MDBList key configured at all,
+    since the lookup itself never touches MDBList.
+    """
+    if not isinstance(ratings_dict, dict):
+        return ratings_dict
+    if rcfg.imdb_rating_source != "dataset":
+        return ratings_dict
+    if not effective_imdb_id:
+        return ratings_dict
+    value = imdb_dataset.get_rating(effective_imdb_id)
+    if value is None:
+        return ratings_dict
+    return {**ratings_dict, "imdb": value}
+
+
+def _merge_direct_tmdb_rating(ratings_dict, tmdb_data: dict, rcfg: "RequestConfig"):
+    """Override the "tmdb" entry in *ratings_dict* with TMDB's own
+    vote_average, when configured to source it directly instead of via
+    MDBList.
+
+    Unlike the IMDb dataset, this costs nothing extra: vote_average rides
+    along in the same TMDB details call already made for genre, year and
+    credits, so this is a pure re-use of data already in hand — no schedule,
+    no local storage, no separate opt-in infrastructure. It works with no
+    MDBList key configured at all, same rationale as the IMDb dataset source.
+
+    SCORE_NORMALISERS["tmdb"] is the identity function because MDBList's own
+    "tmdb" source is already expressed on a 0-100 scale; TMDB's API reports
+    vote_average on a 0-10 scale, so it is rescaled here to match.
+    """
+    if not isinstance(ratings_dict, dict):
+        return ratings_dict
+    if rcfg.tmdb_rating_source != "direct":
+        return ratings_dict
+    vote_average = tmdb_data.get("vote_average") if tmdb_data else None
+    if vote_average is None:
+        return ratings_dict
+    try:
+        vote_average = float(vote_average)
+    except (TypeError, ValueError):
+        return ratings_dict
+    if vote_average <= 0:
+        return ratings_dict
+    return {**ratings_dict, "tmdb": vote_average * 10}
 
 
 def _quality_identity(
@@ -915,6 +976,17 @@ class RequestConfig:
     movie_weights: dict | None = None
     tv_weights:    dict | None = None
     fallback_to_imdb: bool = False
+    # "mdblist" (default): the "imdb" weight comes from the MDBList response,
+    # same as every other weighted source. "dataset": it is looked up locally
+    # from IMDb's own free non-commercial dataset instead (imdb_dataset.py) —
+    # no MDBList call needed for that source specifically, and it still works
+    # when no MDBList key is configured at all. See _merge_imdb_dataset_rating.
+    imdb_rating_source: str = "mdblist"
+    # "mdblist" (default): the "tmdb" weight comes from the MDBList response.
+    # "direct": use TMDB's own vote_average from the metadata call PostersPlus
+    # already makes for genre/year/credits — zero extra requests, and works
+    # with no MDBList key at all. See _merge_direct_tmdb_rating.
+    tmdb_rating_source: str = "mdblist"
 
     logo_language: str = field(default_factory=lambda: _cfg.DEFAULT_LOGO_LANGUAGE)
     # Secondary preferred language ("custom").  Only consulted by the
@@ -1299,6 +1371,10 @@ def build_request_config(params: dict) -> RequestConfig:
     tv_sources = list(_cfg.TV_WEIGHTS.keys())
     cfg.tv_weights = _parse_weights(params.get("tv_weights"), tv_sources)
     cfg.fallback_to_imdb = _b("fallback_to_imdb", cfg.fallback_to_imdb)
+    _irs = params.get("imdb_rating_source", cfg.imdb_rating_source).strip().lower()
+    cfg.imdb_rating_source = _irs if _irs in ("mdblist", "dataset") else cfg.imdb_rating_source
+    _trs = params.get("tmdb_rating_source", cfg.tmdb_rating_source).strip().lower()
+    cfg.tmdb_rating_source = _trs if _trs in ("mdblist", "direct") else cfg.tmdb_rating_source
 
     cfg.logo_language        = (params.get("logo_language", cfg.logo_language).strip().lower())
     cfg.logo_language_secondary = (
@@ -3797,6 +3873,12 @@ async def lifespan(app: FastAPI):
     init_db()
     logger.info(f"Cache initialised (composite TTL {_cfg.COMPOSITE_CACHE_TTL}s / "
                 f"{_cfg.COMPOSITE_CACHE_TTL / 86400:.1f}d)")
+    imdb_dataset.init_db()
+    if imdb_dataset.is_enabled():
+        logger.info(
+            f"IMDb local dataset enabled (refresh every {_cfg.IMDB_DATASET_REFRESH_HOURS}h, "
+            f"{imdb_dataset.row_count()} titles currently loaded)"
+        )
     _HTTP_CLIENT = _make_http_client()
     logger.info("HTTP client initialised")
     # Warn on quality source misconfiguration
@@ -3874,11 +3956,13 @@ async def lifespan(app: FastAPI):
     digital_task = asyncio.create_task(digital_release_poll_loop(_HTTP_CLIENT, _digital_release_ready))
     cache_warm_task = asyncio.create_task(_cache_warm_loop(_digital_release_ready))
     trending_task = asyncio.create_task(_trending_fetch_loop())
+    imdb_dataset_task = asyncio.create_task(imdb_dataset_refresh_loop(_HTTP_CLIENT))
     yield
     prune_task.cancel()
     digital_task.cancel()
     cache_warm_task.cancel()
     trending_task.cancel()
+    imdb_dataset_task.cancel()
     if _background_detection_task is not None:
         _background_detection_task.cancel()
     # Await the cancelled tasks so their finally: blocks finish unwinding
@@ -3891,6 +3975,8 @@ async def lifespan(app: FastAPI):
         await cache_warm_task
     with suppress(asyncio.CancelledError):
         await trending_task
+    with suppress(asyncio.CancelledError):
+        await imdb_dataset_task
     if _background_detection_task is not None:
         with suppress(asyncio.CancelledError):
             await _background_detection_task
@@ -4045,6 +4131,8 @@ async def server_caps(access_key: str = ""):
         "trending_fetch_time":   _cfg.TRENDING_FETCH_TIME,
         "trending_fetch_timezone": _cfg.TRENDING_FETCH_TIMEZONE,
         "trending_next_refresh_hours": next_refresh_hours,
+        "imdb_dataset_enabled":  imdb_dataset.is_enabled(),
+        "imdb_dataset_titles":   imdb_dataset.row_count(),
     }
 
 
@@ -5715,7 +5803,19 @@ async def get_poster(
             ratings_dict   = {}
             genre          = cached_genre or _tmdb_genre
             rel            = cached_release_date
-            score          = "N/A"
+            # MDBList failed (or was never reachable), but the IMDb dataset is
+            # an independent, MDBList-free source — try it before giving up on
+            # a score entirely. calculate_weighted_score returns "N/A" itself
+            # when ratings_dict has nothing usable, so this is safe even when
+            # the dataset has no entry either.
+            ratings_dict = _merge_imdb_dataset_rating(ratings_dict, effective_imdb_id, rcfg)
+            ratings_dict = _merge_direct_tmdb_rating(ratings_dict, tmdb_data, rcfg)
+            score = calculate_weighted_score(
+                ratings_dict,
+                effective_tv_weights if type in ("tv", "series") else effective_movie_weights,
+                fallback_to_imdb=rcfg.fallback_to_imdb,
+                fallback_source=anime_namespace if is_anime else None,
+            )
             keywords       = []
             award_wins     = cached_award_wins
             award_noms     = cached_award_noms
@@ -5763,6 +5863,8 @@ async def get_poster(
                 )
 
             if isinstance(ratings_dict, dict):
+                ratings_dict = _merge_imdb_dataset_rating(ratings_dict, effective_imdb_id, rcfg)
+                ratings_dict = _merge_direct_tmdb_rating(ratings_dict, tmdb_data, rcfg)
                 weights = (
                     effective_tv_weights
                     if type in ("tv", "series")
@@ -5928,6 +6030,8 @@ async def get_poster(
                 "canonical_id":      canonical_id,
                 "rating_provider":   rating_provider,
                 "rating_media_id":   rating_media_id,
+                "imdb_rating_source": rcfg.imdb_rating_source,
+                "tmdb_rating_source": rcfg.tmdb_rating_source,
                 "quality_id":        quality_id,
                 "tmdb_id":           tmdb_id,
                 "type":              type,

--- a/tests/test_imdb_dataset_source.py
+++ b/tests/test_imdb_dataset_source.py
@@ -1,0 +1,284 @@
+"""The IMDb weight can be sourced from a local, MDBList-free dataset instead
+of MDBList's aggregated response.
+
+These tests cover: the dataset module's own enable/lookup/refresh behaviour
+in isolation, and the /poster-side wiring that merges a dataset value into
+whatever MDBList did or didn't return.
+"""
+import asyncio
+import gzip
+import io
+import os
+import sqlite3
+import tempfile
+import unittest
+from unittest.mock import patch
+
+import imdb_dataset
+import main
+
+
+class _FakeResponse:
+    def __init__(self, content: bytes):
+        self.content = content
+
+    def raise_for_status(self):
+        pass
+
+
+class _FakeClient:
+    def __init__(self, content: bytes):
+        self._content = content
+        self.calls = 0
+
+    async def get(self, url, **kwargs):
+        self.calls += 1
+        return _FakeResponse(self._content)
+
+
+def _make_gz_tsv(rows: list[tuple[str, str, str]]) -> bytes:
+    lines = ["tconst\taverageRating\tnumVotes"] + [
+        "\t".join(r) for r in rows
+    ]
+    raw = ("\n".join(lines) + "\n").encode("utf-8")
+    return gzip.compress(raw)
+
+
+class ImdbDatasetDisabledByDefaultTests(unittest.TestCase):
+    def test_disabled_lookup_is_always_none(self):
+        with patch.object(imdb_dataset, "IMDB_DATASET_ENABLED", False):
+            self.assertIsNone(imdb_dataset.get_rating("tt0903747"))
+
+    def test_disabled_status_reports_disabled(self):
+        with patch.object(imdb_dataset, "IMDB_DATASET_ENABLED", False):
+            self.assertFalse(imdb_dataset.is_enabled())
+            self.assertEqual(imdb_dataset.row_count(), 0)
+
+
+class ImdbDatasetLookupTests(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.db_path = os.path.join(self.tmpdir, "imdb_ratings.db")
+        self._patches = [
+            patch.object(imdb_dataset, "IMDB_DATASET_ENABLED", True),
+            patch.object(imdb_dataset, "IMDB_DATASET_PATH", self.db_path),
+            patch.object(imdb_dataset, "IMDB_DATASET_MIN_VOTES", 10),
+        ]
+        for p in self._patches:
+            p.start()
+        imdb_dataset._local.conn = None
+
+    def tearDown(self):
+        for p in self._patches:
+            p.stop()
+        imdb_dataset._local.conn = None
+
+    def _seed(self, rows: list[tuple[str, float, int]]):
+        conn = sqlite3.connect(self.db_path)
+        conn.execute(
+            "CREATE TABLE imdb_ratings (tconst TEXT PRIMARY KEY, rating REAL NOT NULL, votes INTEGER NOT NULL)"
+        )
+        conn.executemany(
+            "INSERT INTO imdb_ratings (tconst, rating, votes) VALUES (?, ?, ?)", rows
+        )
+        conn.commit()
+        conn.close()
+
+    def test_known_id_above_min_votes_returns_rating(self):
+        self._seed([("tt0903747", 9.0, 2_000_000)])
+        self.assertEqual(imdb_dataset.get_rating("tt0903747"), 9.0)
+
+    def test_unknown_id_returns_none(self):
+        self._seed([("tt0903747", 9.0, 2_000_000)])
+        self.assertIsNone(imdb_dataset.get_rating("tt9999999"))
+
+    def test_below_min_votes_is_filtered_out(self):
+        self._seed([("tt0000001", 10.0, 3)])
+        self.assertIsNone(imdb_dataset.get_rating("tt0000001"))
+
+    def test_blank_id_returns_none_without_querying(self):
+        self._seed([("tt0903747", 9.0, 2_000_000)])
+        self.assertIsNone(imdb_dataset.get_rating(""))
+        self.assertIsNone(imdb_dataset.get_rating(None))
+
+
+class ImdbDatasetRefreshTests(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.db_path = os.path.join(self.tmpdir, "imdb_ratings.db")
+        self._patches = [
+            patch.object(imdb_dataset, "IMDB_DATASET_ENABLED", True),
+            patch.object(imdb_dataset, "IMDB_DATASET_PATH", self.db_path),
+            patch.object(imdb_dataset, "IMDB_DATASET_MIN_VOTES", 10),
+        ]
+        for p in self._patches:
+            p.start()
+        imdb_dataset._local.conn = None
+
+    def tearDown(self):
+        for p in self._patches:
+            p.stop()
+        imdb_dataset._local.conn = None
+
+    def test_refresh_parses_and_loads_rows(self):
+        gz = _make_gz_tsv([
+            ("tt0903747", "9.0", "2000000"),
+            ("tt0000001", "5.5", "42"),
+        ])
+        client = _FakeClient(gz)
+        count = asyncio.run(imdb_dataset.refresh_dataset(client))
+        self.assertEqual(count, 2)
+        self.assertEqual(imdb_dataset.get_rating("tt0903747"), 9.0)
+        self.assertEqual(imdb_dataset.get_rating("tt0000001"), 5.5)
+        self.assertEqual(imdb_dataset.row_count(), 2)
+
+    def test_malformed_rows_are_skipped_not_fatal(self):
+        raw = b"tconst\taverageRating\tnumVotes\ntt0903747\t9.0\t2000000\nbad-row-only-one-field\n"
+        gz = gzip.compress(raw)
+        client = _FakeClient(gz)
+        count = asyncio.run(imdb_dataset.refresh_dataset(client))
+        self.assertEqual(count, 1)
+
+    def test_refresh_is_a_noop_when_disabled(self):
+        with patch.object(imdb_dataset, "IMDB_DATASET_ENABLED", False):
+            client = _FakeClient(_make_gz_tsv([("tt0903747", "9.0", "2000000")]))
+            count = asyncio.run(imdb_dataset.refresh_dataset(client))
+            self.assertEqual(count, 0)
+            self.assertEqual(client.calls, 0)
+
+    def test_download_failure_returns_zero_without_raising(self):
+        class _FailingClient:
+            async def get(self, url, **kwargs):
+                raise ConnectionError("boom")
+
+        count = asyncio.run(imdb_dataset.refresh_dataset(_FailingClient()))
+        self.assertEqual(count, 0)
+        self.assertIsNotNone(imdb_dataset._last_refresh_error)
+
+
+class RequestConfigImdbSourceTests(unittest.TestCase):
+    def test_default_source_is_mdblist(self):
+        rcfg = main.build_request_config({})
+        self.assertEqual(rcfg.imdb_rating_source, "mdblist")
+
+    def test_dataset_can_be_selected_via_query_param(self):
+        rcfg = main.build_request_config({"imdb_rating_source": "dataset"})
+        self.assertEqual(rcfg.imdb_rating_source, "dataset")
+
+    def test_invalid_value_falls_back_to_default(self):
+        rcfg = main.build_request_config({"imdb_rating_source": "nonsense"})
+        self.assertEqual(rcfg.imdb_rating_source, "mdblist")
+
+    def test_value_is_case_insensitive(self):
+        rcfg = main.build_request_config({"imdb_rating_source": "DATASET"})
+        self.assertEqual(rcfg.imdb_rating_source, "dataset")
+
+
+class MergeImdbDatasetRatingTests(unittest.TestCase):
+    def _rcfg(self, source="dataset"):
+        rcfg = main.build_request_config({})
+        rcfg.imdb_rating_source = source
+        return rcfg
+
+    def test_noop_when_source_is_mdblist(self):
+        with patch.object(imdb_dataset, "get_rating", return_value=9.0):
+            out = main._merge_imdb_dataset_rating({"tomatoes": 80}, "tt0903747", self._rcfg("mdblist"))
+        self.assertEqual(out, {"tomatoes": 80})
+
+    def test_noop_when_no_imdb_id(self):
+        with patch.object(imdb_dataset, "get_rating", return_value=9.0) as mock_get:
+            out = main._merge_imdb_dataset_rating({"tomatoes": 80}, None, self._rcfg("dataset"))
+        mock_get.assert_not_called()
+        self.assertEqual(out, {"tomatoes": 80})
+
+    def test_noop_when_dataset_has_no_value(self):
+        with patch.object(imdb_dataset, "get_rating", return_value=None):
+            out = main._merge_imdb_dataset_rating({"tomatoes": 80}, "tt0903747", self._rcfg("dataset"))
+        self.assertEqual(out, {"tomatoes": 80})
+
+    def test_dataset_value_is_added_when_absent_from_mdblist(self):
+        with patch.object(imdb_dataset, "get_rating", return_value=9.0):
+            out = main._merge_imdb_dataset_rating({"tomatoes": 80}, "tt0903747", self._rcfg("dataset"))
+        self.assertEqual(out, {"tomatoes": 80, "imdb": 9.0})
+
+    def test_dataset_value_overrides_an_mdblist_imdb_value(self):
+        with patch.object(imdb_dataset, "get_rating", return_value=9.0):
+            out = main._merge_imdb_dataset_rating({"imdb": 7.0}, "tt0903747", self._rcfg("dataset"))
+        self.assertEqual(out, {"imdb": 9.0})
+
+    def test_non_dict_ratings_passed_through_untouched(self):
+        # The rating-fetch-failed / string-sentinel path (FETCH_FAILED etc).
+        out = main._merge_imdb_dataset_rating("N/A", "tt0903747", self._rcfg("dataset"))
+        self.assertEqual(out, "N/A")
+
+    def test_works_end_to_end_with_calculate_weighted_score(self):
+        from ratings import calculate_weighted_score
+        with patch.object(imdb_dataset, "get_rating", return_value=9.0):
+            merged = main._merge_imdb_dataset_rating({}, "tt0903747", self._rcfg("dataset"))
+        score = calculate_weighted_score(merged, {"imdb": 1.0})
+        self.assertEqual(score, 90)  # (9.0 / 10) * 100
+
+
+class MergeDirectTmdbRatingTests(unittest.TestCase):
+    def _rcfg(self, source="direct"):
+        rcfg = main.build_request_config({})
+        rcfg.tmdb_rating_source = source
+        return rcfg
+
+    def test_noop_when_source_is_mdblist(self):
+        out = main._merge_direct_tmdb_rating(
+            {"tomatoes": 80}, {"vote_average": 8.2}, self._rcfg("mdblist")
+        )
+        self.assertEqual(out, {"tomatoes": 80})
+
+    def test_noop_when_tmdb_data_missing_vote_average(self):
+        out = main._merge_direct_tmdb_rating({"tomatoes": 80}, {}, self._rcfg("direct"))
+        self.assertEqual(out, {"tomatoes": 80})
+
+    def test_noop_when_tmdb_data_is_none(self):
+        out = main._merge_direct_tmdb_rating({"tomatoes": 80}, None, self._rcfg("direct"))
+        self.assertEqual(out, {"tomatoes": 80})
+
+    def test_vote_average_is_added_rescaled_to_0_100(self):
+        out = main._merge_direct_tmdb_rating({}, {"vote_average": 8.2}, self._rcfg("direct"))
+        self.assertEqual(out, {"tmdb": 82.0})
+
+    def test_direct_value_overrides_an_mdblist_tmdb_value(self):
+        out = main._merge_direct_tmdb_rating(
+            {"tmdb": 55}, {"vote_average": 8.2}, self._rcfg("direct")
+        )
+        self.assertEqual(out, {"tmdb": 82.0})
+
+    def test_zero_vote_average_is_treated_as_unrated_not_zero_score(self):
+        # An unreleased or brand-new title reports vote_average: 0 with no
+        # votes yet — showing a 0/100 score would be actively misleading.
+        out = main._merge_direct_tmdb_rating({}, {"vote_average": 0}, self._rcfg("direct"))
+        self.assertEqual(out, {})
+
+    def test_non_dict_ratings_passed_through_untouched(self):
+        out = main._merge_direct_tmdb_rating("N/A", {"vote_average": 8.2}, self._rcfg("direct"))
+        self.assertEqual(out, "N/A")
+
+    def test_works_end_to_end_with_calculate_weighted_score(self):
+        from ratings import calculate_weighted_score
+        merged = main._merge_direct_tmdb_rating({}, {"vote_average": 8.2}, self._rcfg("direct"))
+        score = calculate_weighted_score(merged, {"tmdb": 1.0})
+        self.assertEqual(score, 82)
+
+
+class TmdbRatingSourceRequestConfigTests(unittest.TestCase):
+    def test_default_source_is_mdblist(self):
+        rcfg = main.build_request_config({})
+        self.assertEqual(rcfg.tmdb_rating_source, "mdblist")
+
+    def test_direct_can_be_selected_via_query_param(self):
+        rcfg = main.build_request_config({"tmdb_rating_source": "direct"})
+        self.assertEqual(rcfg.tmdb_rating_source, "direct")
+
+    def test_invalid_value_falls_back_to_default(self):
+        rcfg = main.build_request_config({"tmdb_rating_source": "nonsense"})
+        self.assertEqual(rcfg.tmdb_rating_source, "mdblist")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tmdb.py
+++ b/tmdb.py
@@ -380,6 +380,7 @@ async def fetch_poster_metadata(
             "number_of_episodes":    meta.get("number_of_episodes"),
             "tmdb_status":           meta.get("tmdb_status"),
             "vote_count":            meta.get("vote_count"),
+            "vote_average":          meta.get("vote_average"),
             "text_backdrop_path":    meta.get("text_backdrop_path"),
             "original_poster_path":  meta.get("original_poster_path"),
             "poster_langs":          meta.get("poster_langs", {}),
@@ -502,6 +503,11 @@ async def fetch_poster_metadata(
     number_of_episodes   = data.get("number_of_episodes")
     tmdb_status          = data.get("status")   # e.g. "Released", "In Production", "Returning Series"
     vote_count           = data.get("vote_count")
+    # The title's own aggregate score, straight from the same details call
+    # already made for genre/year/credits — no extra API request. 0-10 scale,
+    # same as TMDB's UI. Lets the "tmdb" rating weight be sourced without
+    # MDBList when tmdb_rating_source=direct (see main._merge_direct_tmdb_rating).
+    vote_average         = data.get("vote_average")
     tmdb_release_date    = raw_date or None
     last_air_date        = data.get("last_air_date")
     next_episode         = data.get("next_episode_to_air") or None
@@ -581,6 +587,7 @@ async def fetch_poster_metadata(
         backdrop_path=backdrop_path,
         tmdb_status=tmdb_status,
         vote_count=vote_count,
+        vote_average=vote_average,
         text_backdrop_path=text_backdrop_path,
         original_poster_path=original_poster_path,
         poster_langs=poster_langs,
@@ -602,6 +609,7 @@ async def fetch_poster_metadata(
         "number_of_episodes":   number_of_episodes,
         "tmdb_status":          tmdb_status,
         "vote_count":           vote_count,
+        "vote_average":         vote_average,
         "text_backdrop_path":   text_backdrop_path,
         "original_poster_path": original_poster_path,
         "poster_langs":         poster_langs,


### PR DESCRIPTION
<!--
Base branch must be `dev`. PRs into `main` are closed automatically — see the
banner at the top of this form for which branch you're targeting.
-->

## What this changes

Adds two opt-in, backward-compatible ways to source the "tmdb" and "imdb"
weighted rating inputs without MDBList:

- `tmdb_rating_source=direct` — uses TMDB's own `vote_average`, which is
  already fetched in the same metadata call used for genre/year/credits. No
  extra request, no new config, no MDBList key needed for this source.
- `imdb_rating_source=dataset` — sources the IMDb weight from IMDb's own
  free, no-key, daily-refreshed non-commercial dataset (`title.ratings.tsv.gz`).
  A background task downloads and refreshes it into a local SQLite table on a
  schedule; lookups are a local indexed query, not a per-title network call.
  Configured via `IMDB_DATASET_ENABLED`, `IMDB_DATASET_REFRESH_HOURS`,
  `IMDB_DATASET_MIN_VOTES`, `IMDB_DATASET_PATH`.

Both default to the existing MDBList-sourced behavior (nothing changes unless
you opt in), and both are exposed as dropdowns on the configurator's Weights
tab.

## Why

Every weighted rating source currently comes from MDBList — including the
one labelled "tmdb". For self-hosters who only care about TMDB/IMDb scores
and TMDB-native sashes (trending, Golden Globe, studio/director/cast,
foreign-language, release-status), this removes the need for an MDBList key
— and its paid tier's higher rate limits — entirely for that use case.

As a side benefit, when the IMDb dataset source is enabled, it's also tried
as a fallback if a live MDBList fetch fails, so a temporary MDBList outage
doesn't unconditionally zero out the score for operators using it.

## What's unaffected

MDBList-only sashes (festival, cult classic, true story, Metacritic
must-see, Oscar wins/nominations) and every other weighted rating source
(Letterboxd, Trakt, Rotten Tomatoes, Metacritic, Popcornmeter, Roger Ebert)
still require MDBList — this PR doesn't touch those.

## Testing

`python3 -m pytest tests/ -q` — 276/276 passing (244 pre-existing + 32 new,
covering the dataset module, the merge helpers, and request-config parsing).

Docs updated in `CHANGELOG.md` and a new "Ratings without MDBList" section in
`ADVANCED.md`. `.env.example` also corrects the `MDBLIST_API_KEY` `[Required]`
label, which hasn't been accurate for a while — it now spells out exactly
what does and doesn't work without a key.

## Checklist
- [x] Base branch is `dev`, not `main`
- [x] `python3 -m pytest tests/ -q` passes
- [ ] For a new poster translation: `languages/<code>.json` is a full copy of
      `languages/en.json` with only the **values** translated — keys unchanged,
      none removed. Partial region files fall through to English, not to the
      base language.