### PR TITLE
Send the composite's expiry in Cache-Control

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -171,8 +171,13 @@ IMAGE_FORMAT=webp
 WEBP_QUALITY=85
 JPEG_QUALITY=85
 
-# Adds Cache-Control: public, max-age=<N> to poster responses.
-# 0 disables it (default; recommended unless you front this with a CDN).
+# Adds Cache-Control: public, max-age=<N> to poster responses, capped at the
+# composite's own remaining life so a cached copy never outlives the trending
+# rank or release status baked into it. Use "auto" to advertise that remaining
+# life with no fixed ceiling, which is what a caching client wants: a
+# trending-sashed poster expires in a day, an Ended title lasts the full
+# COMPOSITE_CACHE_TTL. 0 sends no Cache-Control at all (default; recommended
+# unless you front this with a CDN or a caching client).
 CDN_CACHE_TTL=0
 
 # Seconds to keep a composited poster before re-rendering. Pruning runs off this

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,12 @@
 
 ### Metadata And Caching
 
+- Poster responses now advertise the composite's own expiry, so a caching client
+  keeps a trending-sashed poster for a day and a settled title for the full
+  `COMPOSITE_CACHE_TTL`. A configured `CDN_CACHE_TTL` acts as a ceiling the
+  deadline can lower, `CDN_CACHE_TTL=auto` drops the ceiling, and `0` still
+  sends no `Cache-Control`. `304` responses carry the same freshness.
+
 - IMDb ids are now optional. `tmdb_id` is the required identity — it selects the
   artwork and metadata — and `imdb_id` is optional enrichment. Titles TMDB has no
   IMDb link for previously returned an error and, through AIOMetadata, lost their

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ All configuration is done via environment variables. Copy `.env.example` to `.en
 | `QUALITY_OLD_CACHE_DURATION` | `90` | Days to cache quality data for titles older than 2 weeks |
 | `QUALITY_BG_CONCURRENCY` | `5` | Max concurrent background quality fetches |
 | `QUALITY_WAIT_TIMEOUT` | `30` | Maximum seconds to wait when a request enables synchronous quality fetching |
-| `CDN_CACHE_TTL` | `0` | Adds `Cache-Control: public, max-age=N` to poster responses. Set to `0` to disable |
+| `CDN_CACHE_TTL` | `0` | Adds `Cache-Control: public, max-age=N` to poster responses, capped at the composite's remaining life. `auto` advertises that remaining life with no fixed ceiling, so a trending poster expires in a day and a settled title lasts the full `COMPOSITE_CACHE_TTL`. Set to `0` to disable |
 | `IMAGE_FORMAT` | `webp` | Output format for composited posters: `webp` or `jpeg`. WebP gives smaller files at equivalent quality |
 | `JPEG_QUALITY` | `85` | JPEG output quality for composited posters (70–95), used when `IMAGE_FORMAT=jpeg`. Raise to `92` for higher fidelity; lower to reduce file size |
 | `WEBP_QUALITY` | `85` | WebP output quality for composited posters (70–95), used when `IMAGE_FORMAT=webp` (the default) |

--- a/cache.py
+++ b/cache.py
@@ -418,7 +418,13 @@ def _composite_expiry(cache_key: str, cached_at: float) -> float:
 
 
 def get_cached_final_poster(cache_key: str) -> bytes | None:
-    """Return cached JPEG bytes for a fully composited poster, or None on miss/expiry.
+    """Return cached JPEG bytes for a fully composited poster, or None on miss/expiry."""
+    entry = get_cached_final_poster_entry(cache_key)
+    return None if entry is None else entry[0]
+
+
+def get_cached_final_poster_entry(cache_key: str) -> "tuple[bytes, int] | None":
+    """Return (jpeg_bytes, expires_at) for a composited poster, or None on miss.
 
     Checks the in-memory LRU (L1) first; falls through to SQLite (L2) on miss
     and promotes the result to L1 so the next hit is served entirely from RAM.
@@ -433,7 +439,7 @@ def get_cached_final_poster(cache_key: str) -> bytes | None:
                 expires_at, data = entry
                 if now <= expires_at:
                     _composite_l1.move_to_end(cache_key)
-                    return data
+                    return data, int(expires_at)
                 # Nothing sweeps L1 on a timer, so an aged-out entry is dropped
                 # on the read that finds it and the L2 check below takes over.
                 del _composite_l1[cache_key]
@@ -468,13 +474,13 @@ def get_cached_final_poster(cache_key: str) -> bytes | None:
                 _composite_l1.move_to_end(cache_key)
                 while len(_composite_l1) > COMPOSITE_MEM_ENTRIES:
                     _composite_l1.popitem(last=False)
-        return data
+        return data, int(expires_at)
     except Exception as exc:
         logger.error(f"Final poster cache read error: {exc}")
         return None
 
 
-def set_cached_final_poster(cache_key: str, jpeg_bytes: bytes, request_params: str = None, ttl_override: int = None) -> None:
+def set_cached_final_poster(cache_key: str, jpeg_bytes: bytes, request_params: str = None, ttl_override: int = None) -> int:
     """Store a fully composited JPEG poster into L1 (RAM) and L2 (SQLite).
 
     *ttl_override* caps the lifetime, in seconds, for a render that depends on
@@ -482,6 +488,8 @@ def set_cached_final_poster(cache_key: str, jpeg_bytes: bytes, request_params: s
     release status.  It is a cap on the jittered TTL rather than a value added
     to it, so a one-day override really means one day and not one day plus up
     to COMPOSITE_CACHE_TTL_JITTER.
+
+    Returns the unix time this composite expires.
     """
     now = int(time.time())
     ttl = COMPOSITE_CACHE_TTL + _ttl_jitter(cache_key, COMPOSITE_CACHE_TTL_JITTER)
@@ -524,6 +532,9 @@ def set_cached_final_poster(cache_key: str, jpeg_bytes: bytes, request_params: s
             get_db().commit()
     except Exception as exc:
         logger.error(f"Final poster cache write error: {exc}")
+
+    return expires_at
+
 
 def delete_cached_final_poster(cache_key: str) -> None:
     """Remove a composited poster from both L1 (RAM) and L2 (SQLite) caches."""

--- a/config.py
+++ b/config.py
@@ -145,10 +145,12 @@ KITSU_API_BASE        = os.environ.get("KITSU_API_BASE", "https://kitsu.io/api/e
 SERVER_MDBLIST_KEYS: list[str] = [k for k in [SERVER_MDBLIST_KEY, SERVER_MDBLIST_KEY_2] if k]
 
 # Workers
-# CDN cache TTL (seconds). When > 0, poster responses include a
-# Cache-Control: public header so Cloudflare (or any CDN) caches them at the
-# edge. Set to 0 to disable (e.g. when running without a CDN).
-CDN_CACHE_TTL         = int(os.environ.get("CDN_CACHE_TTL", "0"))
+# CDN cache TTL. When > 0, poster responses include a Cache-Control: public
+# header, capped at the composite's remaining lifetime. "auto" advertises that
+# remaining lifetime with no fixed ceiling. Set to 0 to send no Cache-Control.
+_CDN_CACHE_TTL_RAW    = os.environ.get("CDN_CACHE_TTL", "0").strip().lower()
+CDN_CACHE_TTL_AUTO    = _CDN_CACHE_TTL_RAW == "auto"
+CDN_CACHE_TTL         = 0 if CDN_CACHE_TTL_AUTO else int(_CDN_CACHE_TTL_RAW or "0")
 # Image format for composited posters (webp or jpeg). webp is recommended.
 IMAGE_FORMAT          = os.environ.get("IMAGE_FORMAT", "webp").lower()
 # Normalise the common "jpg" alias to the canonical "jpeg" that PIL's save()

--- a/main.py
+++ b/main.py
@@ -566,7 +566,7 @@ from i18n import load_languages, translate_genre, translate_sash
 from cache import (
     get_cached_quality,
     get_cached_rating,
-    get_cached_final_poster,
+    get_cached_final_poster_entry,
     set_cached_final_poster,
     delete_cached_final_poster,
     get_cached_tmdb_poster,
@@ -4722,7 +4722,10 @@ async def get_logo(
 # ---------------------------------------------------------------------------
 
 def _apply_poster_cache_headers(
-    response: Response, final_cache_key: str | None, provisional: bool
+    response: Response,
+    final_cache_key: str | None,
+    provisional: bool,
+    expires_at: int | None = None,
 ) -> None:
     """Attach the validator and freshness headers a poster response has earned.
 
@@ -4737,6 +4740,9 @@ def _apply_poster_cache_headers(
     to arrive until a setting change rewrote the URL and minted a new key.
 
     A provisional render therefore ships no validator and asks not to be stored.
+
+    *expires_at* is the composite's own deadline, which caps the advertised
+    max-age so a cached copy never outlives the facts baked into it.
     """
     if provisional:
         response.headers["Cache-Control"] = "no-store, no-cache, must-revalidate"
@@ -4748,8 +4754,23 @@ def _apply_poster_cache_headers(
     if _cfg.DISABLE_COMPOSITE_CACHE:
         response.headers["Cache-Control"] = "no-store, no-cache, must-revalidate"
         response.headers["Pragma"] = "no-cache"
+        return
+
+    remaining = None
+    if expires_at is not None:
+        remaining = max(0, int(expires_at) - int(time.time()))
+
+    if _cfg.CDN_CACHE_TTL_AUTO:
+        max_age = remaining
     elif _cfg.CDN_CACHE_TTL > 0:
-        response.headers["Cache-Control"] = f"public, max-age={_cfg.CDN_CACHE_TTL}"
+        max_age = _cfg.CDN_CACHE_TTL if remaining is None else min(_cfg.CDN_CACHE_TTL, remaining)
+    else:
+        max_age = None
+
+    if max_age:
+        response.headers["Cache-Control"] = f"public, max-age={max_age}"
+    elif max_age == 0:
+        response.headers["Cache-Control"] = "public, max-age=0, must-revalidate"
 
 
 @app.get("/poster")
@@ -5052,18 +5073,21 @@ async def get_poster(
             if is_anime
             else f"{canonical_id}:{tmdb_id}:{type}:{_params_hash}"
         )
-        cached_jpeg = None if _force_refresh else get_cached_final_poster(final_cache_key)
+        _cached_entry = None if _force_refresh else get_cached_final_poster_entry(final_cache_key)
         if _force_refresh:
             logger.info(f"Force refresh (nocache) for {final_cache_key} — bypassing cache read")
-        if cached_jpeg is not None:
+        if _cached_entry is not None:
+            cached_jpeg, _cached_expires_at = _cached_entry
             logger.info(f"Final poster cache hit for {final_cache_key}")
             etag = f'"{final_cache_key}"'
             if request.headers.get("if-none-match") == etag:
-                return Response(status_code=304)
+                _304 = Response(status_code=304)
+                _apply_poster_cache_headers(_304, final_cache_key, False, _cached_expires_at)
+                return _304
             _hit_resp = Response(content=cached_jpeg, media_type=f"image/{_cfg.IMAGE_FORMAT}")
             # Only a finished render is ever written to the composite cache, so
             # a cache hit is never provisional.
-            _apply_poster_cache_headers(_hit_resp, final_cache_key, False)
+            _apply_poster_cache_headers(_hit_resp, final_cache_key, False, _cached_expires_at)
             return _hit_resp
     else:
         final_cache_key = None
@@ -5074,7 +5098,7 @@ async def get_poster(
     # the pipeline.  Quality-override requests (final_cache_key=None) are
     # always rendered independently.
     # ------------------------------------------------------------------
-    _render_fut: "asyncio.Future[tuple[bytes, bool]] | None" = None
+    _render_fut: "asyncio.Future[tuple[bytes, bool, int | None]] | None" = None
     if final_cache_key is not None:
         _existing_fut = _render_inflight.get(final_cache_key)
         if _existing_fut is not None:
@@ -5083,9 +5107,11 @@ async def get_poster(
                 # The render we rode on decides our headers too: riding on a
                 # provisional one and then stamping an ETag would cache exactly
                 # the poster it was withheld to avoid.
-                _coal_bytes, _coal_provisional = await _existing_fut
+                _coal_bytes, _coal_provisional, _coal_expires_at = await _existing_fut
                 _coal_resp = Response(content=_coal_bytes, media_type=f"image/{_cfg.IMAGE_FORMAT}")
-                _apply_poster_cache_headers(_coal_resp, final_cache_key, _coal_provisional)
+                _apply_poster_cache_headers(
+                    _coal_resp, final_cache_key, _coal_provisional, _coal_expires_at
+                )
                 return _coal_resp
             except Exception:
                 # The in-flight render failed; fall through and try ourselves.
@@ -6386,6 +6412,7 @@ async def get_poster(
             quality_pending or _detection_deferred or rating_failed
             or _rating_backoff_active or _anime_art_missing
         )
+        _composite_expires_at: int | None = None
         if final_cache_key is not None and not _render_provisional:
             # A composite must not outlive the facts baked into it.  Trending
             # rank turns over daily; release status has its own tier (Cinema and
@@ -6405,7 +6432,7 @@ async def get_poster(
                     else min(_ttl_override, _status_ttl)
                 )
 
-            set_cached_final_poster(
+            _composite_expires_at = set_cached_final_poster(
                 final_cache_key,
                 img_bytes,
                 request_params=_sanitize_request_params(request.url.query),
@@ -6414,10 +6441,12 @@ async def get_poster(
             logger.info(f"Final poster cached for {final_cache_key}")
 
         if _render_fut is not None:
-            _render_fut.set_result((img_bytes, _render_provisional))
+            _render_fut.set_result((img_bytes, _render_provisional, _composite_expires_at))
 
         response = Response(content=img_bytes, media_type=f"image/{_cfg.IMAGE_FORMAT}")
-        _apply_poster_cache_headers(response, final_cache_key, _render_provisional)
+        _apply_poster_cache_headers(
+            response, final_cache_key, _render_provisional, _composite_expires_at
+        )
         return response
 
     except ValueError as exc:

--- a/tests/test_composite_cache_control.py
+++ b/tests/test_composite_cache_control.py
@@ -1,0 +1,91 @@
+"""Cache-Control on a poster response should follow the composite's deadline."""
+
+import time
+import unittest
+
+from fastapi import Response
+
+import main
+
+
+KEY = "tt0087332:620:movie:abc123"
+
+
+class CompositeCacheControlTests(unittest.TestCase):
+    def setUp(self):
+        self.disable_composite = main._cfg.DISABLE_COMPOSITE_CACHE
+        self.cdn_ttl = main._cfg.CDN_CACHE_TTL
+        self.cdn_auto = main._cfg.CDN_CACHE_TTL_AUTO
+        main._cfg.DISABLE_COMPOSITE_CACHE = False
+        main._cfg.CDN_CACHE_TTL = 0
+        main._cfg.CDN_CACHE_TTL_AUTO = False
+
+    def tearDown(self):
+        main._cfg.DISABLE_COMPOSITE_CACHE = self.disable_composite
+        main._cfg.CDN_CACHE_TTL = self.cdn_ttl
+        main._cfg.CDN_CACHE_TTL_AUTO = self.cdn_auto
+
+    def _cache_control(self, expires_in=None, provisional=False, key=KEY):
+        resp = Response(content=b"")
+        expires_at = None if expires_in is None else int(time.time()) + expires_in
+        main._apply_poster_cache_headers(resp, key, provisional, expires_at)
+        return resp.headers.get("cache-control")
+
+    def _max_age(self, cache_control):
+        self.assertIsNotNone(cache_control)
+        for part in cache_control.split(","):
+            part = part.strip()
+            if part.startswith("max-age="):
+                return int(part.split("=", 1)[1])
+        self.fail(f"no max-age in {cache_control!r}")
+
+    def test_auto_advertises_the_composite_deadline(self):
+        main._cfg.CDN_CACHE_TTL_AUTO = True
+        self.assertAlmostEqual(self._max_age(self._cache_control(86400)), 86400, delta=2)
+
+    def test_auto_lets_a_stable_title_keep_the_full_composite_ttl(self):
+        main._cfg.CDN_CACHE_TTL_AUTO = True
+        self.assertAlmostEqual(self._max_age(self._cache_control(604800)), 604800, delta=2)
+
+    def test_auto_says_nothing_when_there_is_no_composite(self):
+        main._cfg.CDN_CACHE_TTL_AUTO = True
+        self.assertIsNone(self._cache_control(None, key=None))
+
+    def test_an_expired_composite_is_served_but_must_be_revalidated(self):
+        main._cfg.CDN_CACHE_TTL_AUTO = True
+        self.assertEqual(
+            self._cache_control(-60), "public, max-age=0, must-revalidate"
+        )
+
+    def test_a_configured_ttl_is_capped_by_the_composite_deadline(self):
+        main._cfg.CDN_CACHE_TTL = 604800
+        self.assertAlmostEqual(self._max_age(self._cache_control(86400)), 86400, delta=2)
+
+    def test_the_composite_deadline_never_extends_a_configured_ttl(self):
+        main._cfg.CDN_CACHE_TTL = 300
+        self.assertEqual(self._max_age(self._cache_control(604800)), 300)
+
+    def test_a_configured_ttl_still_applies_with_no_deadline_to_hand(self):
+        main._cfg.CDN_CACHE_TTL = 86400
+        self.assertEqual(self._cache_control(None), "public, max-age=86400")
+
+    def test_zero_still_means_send_nothing(self):
+        self.assertIsNone(self._cache_control(86400))
+
+    def test_a_provisional_render_is_still_never_given_freshness(self):
+        main._cfg.CDN_CACHE_TTL_AUTO = True
+        self.assertEqual(
+            self._cache_control(86400, provisional=True),
+            "no-store, no-cache, must-revalidate",
+        )
+
+    def test_composite_caching_off_still_wins(self):
+        main._cfg.CDN_CACHE_TTL_AUTO = True
+        main._cfg.DISABLE_COMPOSITE_CACHE = True
+        self.assertEqual(
+            self._cache_control(86400), "no-store, no-cache, must-revalidate"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_provisional_poster_headers.py
+++ b/tests/test_provisional_poster_headers.py
@@ -11,6 +11,7 @@ provisionally before any tokens exist.
 """
 
 import asyncio
+import time
 import unittest
 
 from fastapi import Response
@@ -23,12 +24,15 @@ class ProvisionalHeaderTests(unittest.TestCase):
     def setUp(self):
         self.disable_composite = main._cfg.DISABLE_COMPOSITE_CACHE
         self.cdn_ttl = main._cfg.CDN_CACHE_TTL
+        self.cdn_auto = main._cfg.CDN_CACHE_TTL_AUTO
         main._cfg.DISABLE_COMPOSITE_CACHE = False
         main._cfg.CDN_CACHE_TTL = 0
+        main._cfg.CDN_CACHE_TTL_AUTO = False
 
     def tearDown(self):
         main._cfg.DISABLE_COMPOSITE_CACHE = self.disable_composite
         main._cfg.CDN_CACHE_TTL = self.cdn_ttl
+        main._cfg.CDN_CACHE_TTL_AUTO = self.cdn_auto
 
     def _headers(self, provisional, key="tt0087332:620:movie:abc123"):
         resp = Response(content=b"")
@@ -84,7 +88,7 @@ class CoalescedRenderTests(unittest.TestCase):
         self.access_key = main._cfg.ACCESS_KEY
         self.tmdb_key = main._cfg.SERVER_TMDB_KEY
         self.disable_composite = main._cfg.DISABLE_COMPOSITE_CACHE
-        self.real_get_cached = main.get_cached_final_poster
+        self.real_get_cached = main.get_cached_final_poster_entry
         main._cfg.ACCESS_KEY = ""
         main._cfg.SERVER_TMDB_KEY = "test-key"
         main._cfg.DISABLE_COMPOSITE_CACHE = False
@@ -93,7 +97,7 @@ class CoalescedRenderTests(unittest.TestCase):
         main._cfg.ACCESS_KEY = self.access_key
         main._cfg.SERVER_TMDB_KEY = self.tmdb_key
         main._cfg.DISABLE_COMPOSITE_CACHE = self.disable_composite
-        main.get_cached_final_poster = self.real_get_cached
+        main.get_cached_final_poster_entry = self.real_get_cached
         main._render_inflight.clear()
 
     def _coalesced_response(self, payload, provisional):
@@ -108,15 +112,17 @@ class CoalescedRenderTests(unittest.TestCase):
         """
         seen = []
         with TestClient(main.app) as client:
-            main.get_cached_final_poster = lambda key: (seen.append(key), b"jpeg")[1]
+            main.get_cached_final_poster_entry = lambda key: (
+                seen.append(key), (b"jpeg", int(time.time()) + 3600)
+            )[1]
             self.assertEqual(client.get("/poster", params=self.PARAMS).status_code, 200)
             key = seen[0]
 
-            main.get_cached_final_poster = lambda _key: None
+            main.get_cached_final_poster_entry = lambda _key: None
 
             async def _seed():
                 fut = asyncio.get_running_loop().create_future()
-                fut.set_result((payload, provisional))
+                fut.set_result((payload, provisional, None))
                 main._render_inflight[key] = fut
 
             # The future is awaited on the app's loop, so seed it from there.


### PR DESCRIPTION
Hey! In AIOMetadata's poster cache you can set how long to keep images from a
given provider, with an option to just infer it from what the provider sends.
PostersPlus doesn't send a `max-age`, so there's nothing to infer from and it
falls back to one fixed number for every poster.

That number can't be right for both cases: a day and settled titles get
re-rendered daily for nothing, a week and a "Number 1 Today" sash sticks around after
it stopped being true.

`set_cached_final_poster` already works out when a composite actually expires
(trending caps it at a day, `Cinema`/`Production` at a day, `Ended` keeps the
full `COMPOSITE_CACHE_TTL`), so this just sends that value out with the
response:

- `CDN_CACHE_TTL=<n>` still works and now acts as a ceiling the composite
  deadline can lower, never raise
- `CDN_CACHE_TTL=auto` advertises the composite deadline with no ceiling
- `CDN_CACHE_TTL=0` unchanged, sends no `Cache-Control`
- `304`s carry the same freshness, so a revalidation isn't wasted

